### PR TITLE
disallow local computation from capturing mutable references

### DIFF
--- a/chorus_book/src/guide-choreography.md
+++ b/chorus_book/src/guide-choreography.md
@@ -57,7 +57,7 @@ let num_at_alice: Located<i32, Alice> = op.locally(Alice, |_| {
 # }
 ```
 
-The computation closure takes `Unwrapper`. Using the `Unwrapper`, you can access the value of a located value.
+The computation closure takes `Unwrapper`. Using the `Unwrapper`, you can get a reference out of a located value.
 
 ```rust
 {{#include ./header.txt}}
@@ -68,10 +68,10 @@ The computation closure takes `Unwrapper`. Using the `Unwrapper`, you can access
 let num_at_alice: Located<i32, Alice> = op.locally(Alice, |_| {
     42
 });
-op.locally(Alice, |unwrapper| {
-    let num: i32 = unwrapper.unwrap(num_at_alice);
+op.locally(Alice, |un| {
+    let num: &i32 = un.unwrap(&num_at_alice);
     println!("The number at Alice is {}", num);
-    assert_eq!(num, 42);
+    assert_eq!(*num, 42);
 });
 #     }
 # }
@@ -87,9 +87,9 @@ Note that you can unwrap a located value only at the location where the located 
 #     fn run(self, op: &impl ChoreoOp) {
 // This code will fail to compile
 let num_at_alice = op.locally(Alice, |_| { 42 });
-op.locally(Bob, |unwrapper| {
+op.locally(Bob, |un| {
     // Only values located at Bob can be unwrapped here
-    let num_at_alice: i32 = unwrapper.unwrap(num_at_alice);
+    let num_at_alice: &i32 = un.unwrap(&num_at_alice);
 });
 #     }
 # }
@@ -114,8 +114,8 @@ let num_at_alice: Located<i32, Alice> = op.locally(Alice, |_| {
 // Send the value from Alice to Bob
 let num_at_bob: Located<i32, Bob> = op.comm(Alice, Bob, &num_at_alice);
 // Bob can now access the value
-op.locally(Bob, |unwrapper| {
-    let num_at_bob: i32 = unwrapper.unwrap(num_at_bob);
+op.locally(Bob, |un| {
+    let num_at_bob: &i32 = un.unwrap(&num_at_bob);
     println!("The number at Bob is {}", num_at_bob);
 });
 #     }

--- a/chorus_book/src/guide-colocally.md
+++ b/chorus_book/src/guide-colocally.md
@@ -26,14 +26,14 @@ impl Choreography for DemoChoreography {
         });
         let x_at_bob = op.comm(Alice, Bob, &x_at_alice);
         let is_even_at_bob: Located<bool, Bob> = op.locally(Bob, |un| {
-            let x = un.unwrap(x_at_bob.clone());
+            let x = un.unwrap(&x_at_bob);
             x % 2 == 0
         });
         let is_even: bool = op.broadcast(Bob, is_even_at_bob);
         if is_even {
             let x_at_carol = op.comm(Bob, Carol, &x_at_bob);
             op.locally(Carol, |un| {
-                let x = un.unwrap(x_at_carol);
+                let x = un.unwrap(&x_at_carol);
                 println!("x is even: {}", x);
             });
         }
@@ -53,14 +53,14 @@ struct BobCarolChoreography {
 impl Choreography for BobCarolChoreography {
     fn run(self, op: &impl ChoreoOp) {
         let is_even_at_bob: Located<bool, Bob> = op.locally(Bob, |un| {
-            let x = un.unwrap(self.x_at_bob.clone());
+            let x = un.unwrap(&self.x_at_bob);
             x % 2 == 0
         });
         let is_even: bool = op.broadcast(Bob, is_even_at_bob);
         if is_even {
             let x_at_carol = op.comm(Bob, Carol, &self.x_at_bob);
             op.locally(Carol, |un| {
-                let x = un.unwrap(x_at_carol);
+                let x = un.unwrap(&x_at_carol);
                 println!("x is even: {}", x);
             });
         }
@@ -81,14 +81,14 @@ Notice that the `BobCarolChoreography` only describes the behavior of Bob and Ca
 # impl Choreography for BobCarolChoreography {
 #     fn run(self, op: &impl ChoreoOp) {
 #         let is_even_at_bob: Located<bool, Bob> = op.locally(Bob, |un| {
-#             let x = un.unwrap(self.x_at_bob.clone());
+#             let x = un.unwrap(&self.x_at_bob);
 #             x % 2 == 0
 #         });
 #         let is_even: bool = op.broadcast(Bob, is_even_at_bob);
 #         if is_even {
 #             let x_at_carol = op.comm(Bob, Carol, &self.x_at_bob);
 #             op.locally(Carol, |un| {
-#                 let x = un.unwrap(x_at_carol);
+#                 let x = un.unwrap(&x_at_carol);
 #                 println!("x is even: {}", x);
 #             });
 #         }
@@ -133,14 +133,14 @@ struct BobCarolChoreography {
 impl Choreography<BobCarolResult> for BobCarolChoreography {
     fn run(self, op: &impl ChoreoOp) -> BobCarolResult {
         let is_even_at_bob: Located<bool, Bob> = op.locally(Bob, |un| {
-            let x = un.unwrap(self.x_at_bob.clone());
+            let x = un.unwrap(&self.x_at_bob);
             x % 2 == 0
         });
         let is_even: bool = op.broadcast(Bob, is_even_at_bob.clone());
         if is_even {
             let x_at_carol = op.comm(Bob, Carol, &self.x_at_bob);
             op.locally(Carol, |un| {
-                let x = un.unwrap(x_at_carol);
+                let x = un.unwrap(&x_at_carol);
                 println!("x is even: {}", x);
             });
         }

--- a/chorus_book/src/guide-input-and-output.md
+++ b/chorus_book/src/guide-input-and-output.md
@@ -56,8 +56,8 @@ struct DemoChoreography {
 
 impl Choreography for DemoChoreography {
     fn run(self, op: &impl ChoreoOp) {
-        op.locally(Alice, |unwrapper| {
-            let input = unwrapper.unwrap(self.input);
+        op.locally(Alice, |un| {
+            let input = un.unwrap(&self.input);
             println!("Input at Alice: {}", input);
         });
     }
@@ -82,8 +82,8 @@ To run the sample choreography above at Alice, we use the `local` method to cons
 #
 # impl Choreography for DemoChoreography {
 #     fn run(self, op: &impl ChoreoOp) {
-#         op.locally(Alice, |unwrapper| {
-#             let input = unwrapper.unwrap(self.input);
+#         op.locally(Alice, |un| {
+#             let input = un.unwrap(&self.input);
 #             println!("Input at Alice: {}", input);
 #         });
 #     }
@@ -108,8 +108,8 @@ For Bob, we use the `remote` method to construct the located value.
 #
 # impl Choreography for DemoChoreography {
 #     fn run(self, op: &impl ChoreoOp) {
-#         op.locally(Alice, |unwrapper| {
-#             let input = unwrapper.unwrap(self.input);
+#         op.locally(Alice, |un| {
+#             let input = un.unwrap(&self.input);
 #             println!("Input at Alice: {}", input);
 #         });
 #     }

--- a/chorus_book/src/guide-runner.md
+++ b/chorus_book/src/guide-runner.md
@@ -30,8 +30,8 @@ impl Choreography<Located<u32, Carol>> for SumChoreography {
         let x_at_carol = op.comm(Alice, Carol, &self.x_at_alice);
         let y_at_carol = op.comm(Bob, Carol, &self.y_at_bob);
         op.locally(Carol, |un| {
-            let x = un.unwrap(x_at_carol);
-            let y = un.unwrap(y_at_carol);
+            let x = un.unwrap(&x_at_carol);
+            let y = un.unwrap(&y_at_carol);
             x + y
         })
     }

--- a/chorus_lib/examples/bookseller.rs
+++ b/chorus_lib/examples/bookseller.rs
@@ -35,7 +35,7 @@ impl Choreography for BooksellerChoreography {
         });
         let title_at_seller = op.comm(Buyer, Seller, &title_at_buyer);
         let price_at_seller = op.locally(Seller, |un| {
-            let title = un.unwrap(title_at_seller.clone());
+            let title = un.unwrap(&title_at_seller);
             if let Some((price, _)) = get_book(&title) {
                 return Some(price);
             }
@@ -43,9 +43,9 @@ impl Choreography for BooksellerChoreography {
         });
         let price_at_buyer = op.comm(Seller, Buyer, &price_at_seller);
         let decision_at_buyer = op.locally(Buyer, |un| {
-            if let Some(price) = un.unwrap(price_at_buyer) {
+            if let Some(price) = un.unwrap(&price_at_buyer) {
                 println!("Price is {}", price);
-                return price < BUDGET;
+                return *price < BUDGET;
             }
             println!("The book does not exist");
             return false;
@@ -53,13 +53,13 @@ impl Choreography for BooksellerChoreography {
         let decision = op.broadcast(Buyer, decision_at_buyer);
         if decision {
             let delivery_date_at_seller = op.locally(Seller, |un| {
-                let title = un.unwrap(title_at_seller);
+                let title = un.unwrap(&title_at_seller);
                 let (_, delivery_date) = get_book(&title).unwrap();
                 return delivery_date;
             });
             let delivery_date_at_buyer = op.comm(Seller, Buyer, &delivery_date_at_seller);
             op.locally(Buyer, |un| {
-                let delivery_date = un.unwrap(delivery_date_at_buyer);
+                let delivery_date = un.unwrap(&delivery_date_at_buyer);
                 println!("The book will be delivered on {}", delivery_date);
             });
         } else {

--- a/chorus_lib/examples/hello.rs
+++ b/chorus_lib/examples/hello.rs
@@ -28,7 +28,7 @@ impl Choreography for HelloWorldChoreography {
         let msg_at_bob = op.comm(Alice, Bob, &msg_at_alice);
         // Print the received message at Bob
         op.locally(Bob, |un| {
-            let msg = un.unwrap(msg_at_bob);
+            let msg = un.unwrap(&msg_at_bob);
             println!("Bob received a message: {}", msg);
             msg
         });

--- a/chorus_lib/examples/input-output.rs
+++ b/chorus_lib/examples/input-output.rs
@@ -14,10 +14,8 @@ struct DemoChoreography {
 impl Choreography for DemoChoreography {
     fn run(self, op: &impl ChoreoOp) {
         op.locally(Alice, |un| {
-            let _s = un.unwrap(self.input.clone());
-        });
-        op.locally(Alice, |un| {
-            let _s = un.unwrap(self.input);
+            let s = un.unwrap(&self.input);
+            println!("Alice received: {}", s);
         });
     }
 }

--- a/chorus_lib/examples/runner.rs
+++ b/chorus_lib/examples/runner.rs
@@ -27,15 +27,15 @@ struct BobCarolChoreography {
 impl Choreography<BobCarolResult> for BobCarolChoreography {
     fn run(self, op: &impl ChoreoOp) -> BobCarolResult {
         let is_even_at_bob: Located<bool, Bob> = op.locally(Bob, |un| {
-            let x = un.unwrap(self.x_at_bob.clone());
+            let x = un.unwrap(&self.x_at_bob);
             x % 2 == 0
         });
         let is_even: bool = op.broadcast(Bob, is_even_at_bob.clone());
         if is_even {
             let x_at_carol = op.comm(Bob, Carol, &self.x_at_bob);
             op.locally(Carol, |un| {
-                let x = un.unwrap(x_at_carol);
-                println!("x is even: {}", x);
+                let x = un.unwrap(&x_at_carol);
+                println!("x is even: {}", *x);
             });
         }
         BobCarolResult {
@@ -59,12 +59,12 @@ impl Choreography for MainChoreography {
             BobCarolChoreography { x_at_bob },
         );
         op.locally(Bob, |un| {
-            let is_even = un.unwrap(is_even_at_bob);
+            let is_even = un.unwrap(&is_even_at_bob);
             assert!(is_even);
             println!("Bob: x is even: {}", is_even);
         });
         op.locally(Carol, |un| {
-            let is_even = un.unwrap(is_even_at_carol);
+            let is_even = un.unwrap(&is_even_at_carol);
             assert!(is_even);
             println!("Carol: x is even: {}", is_even);
         });

--- a/chorus_lib/src/core.rs
+++ b/chorus_lib/src/core.rs
@@ -95,9 +95,9 @@ pub struct Unwrapper<L1: ChoreographyLocation> {
 }
 
 impl<L1: ChoreographyLocation> Unwrapper<L1> {
-    /// Takes the value located at the current location and returns its value
-    pub fn unwrap<V>(&self, located: Located<V, L1>) -> V {
-        located.value.unwrap()
+    /// Takes a reference to the located value at the current location and returns its reference
+    pub fn unwrap<'a, V>(&self, located: &'a Located<V, L1>) -> &'a V {
+        located.value.as_ref().unwrap()
     }
 }
 
@@ -117,7 +117,7 @@ pub trait ChoreoOp {
     fn locally<V, L1: ChoreographyLocation>(
         &self,
         location: L1,
-        computation: impl FnOnce(Unwrapper<L1>) -> V,
+        computation: impl Fn(Unwrapper<L1>) -> V,
     ) -> Located<V, L1>;
     /// Performs a communication between two locations.
     ///
@@ -228,7 +228,7 @@ impl<L1: ChoreographyLocation, B: Transport> Projector<L1, B> {
             fn locally<V, L1: ChoreographyLocation>(
                 &self,
                 location: L1,
-                computation: impl FnOnce(Unwrapper<L1>) -> V,
+                computation: impl Fn(Unwrapper<L1>) -> V,
             ) -> Located<V, L1> {
                 if location.name() == self.target {
                     let unwrapper = Unwrapper {
@@ -341,7 +341,7 @@ impl Runner {
             fn locally<V, L1: ChoreographyLocation>(
                 &self,
                 _location: L1,
-                computation: impl FnOnce(Unwrapper<L1>) -> V,
+                computation: impl Fn(Unwrapper<L1>) -> V,
             ) -> Located<V, L1> {
                 let unwrapper = Unwrapper {
                     phantom: PhantomData,


### PR DESCRIPTION
Consider the following choreography:

```rust
struct DemoChoreography;

impl Choreography for HelloWorldChoreography {
    fn run(self, op: &impl ChoreoOp) {
        let mut b = false;
        op.locally(Alice, |_| {
            b = true;
        });
        let v_at_bob = op.locally(Bob, |_| 1);
        if b {
            op.comm(Bob, Alice, &v_at_bob);
        }
    }
}
```

This was valid until ChoRus v0.1.2, but this simple program led to a deadlock. Here, we have a mutable variable `b` that is initially set to `false`. Alice changes this value to `true` and takes the `then` branch on the if statement, while the value remains `false` on Bob, and it doesn’t go into the `then` branch. Because Alice expects Bob to send data, but Bob never sends the value, this will lead to a deadlock.

The problem is that local computations (second argument of `locally`) was `FnOnce` which can move ownership. We don't want local computation to mutate non-located values because those values can be used for branching and can lead to different execution paths. Changing the `FnMut` does not solve the problem because it can still have mutable references.

The only option is to require local computation closures to implement `Fn`. With this change, the local computation can only access outside variables (including located values) through immutable references. Now, the code above does not compile because the closure cannot mutate outside variables.

<img width="801" alt="Screenshot 2023-08-11 at 11 12 43" src="https://github.com/lsd-ucsc/ChoRus/assets/10496155/372a7575-8a32-4dbe-bded-d6d5f9039ced">

For convenience, this PR changes the interface of `unwrap` to take a reference to a located value and returns the reference to the wrapped value. This should not affect how users write choreographies because located values should be immutable. 

As illustrated in the tic-tac-toe example, `broadcast` still takes ownership of located values and returns the unwrapped value with its ownership. This can be used to implement branching.