### PR TITLE
switch from reqwest to ureq

### DIFF
--- a/chorus_lib/Cargo.toml
+++ b/chorus_lib/Cargo.toml
@@ -14,11 +14,11 @@ keywords = ["choreography"]
 
 [dependencies]
 chorus_derive = { version = "0.1.0", path = "../chorus_derive" }
-reqwest = { version = "0.11.18", features = ["blocking"] }
 retry = "2.0.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.104"
 tiny_http = "0.12.0"
+ureq = "2.7.1"
 
 [dev-dependencies]
 chrono = { version = "0.4.26", features = ["serde"] }

--- a/cspell.json
+++ b/cspell.json
@@ -14,10 +14,10 @@
     "Deque",
     "Pluggable",
     "println",
-    "reqwest",
     "serde",
     "struct",
     "TAPL",
-    "unwrapper"
+    "unwrapper",
+    "ureq"
   ]
 }


### PR DESCRIPTION
This PR changes the library used to make HTTP requests from `reqwest` to `ureq`. `ureq` has fewer dependencies and this PR should make the build faster.