### PR TITLE
Projector available locations

### DIFF
--- a/chorus_book/src/guide-choreography.md
+++ b/chorus_book/src/guide-choreography.md
@@ -9,7 +9,7 @@ struct HelloWorldChoreography;
 
 // 2. Implement the `Choreography` trait
 impl Choreography for HelloWorldChoreography {
-    type L = hlist!(Alice);
+    type L = LocationSet!(Alice);
     fn run(self, op: &impl ChoreoOp<Self::L>) {
         // 3. Use the `op` parameter to access operators
         op.locally(Alice, |_| {
@@ -21,7 +21,7 @@ impl Choreography for HelloWorldChoreography {
 
 `Choreography` must implement the `run` method which defines the behavior of the system. The `run` method takes a reference to an object that implements the `ChoreoOp` trait. The `ChoreoOp` trait provides choreographic operators such as `locally` and `comm`.
 
-Also, each `Choreography` has an associated type `L`, which is the set of `ChoreographyLocation`s it can operate on. To build a set of locations, you can use the macro `hlist!`.
+Also, each `Choreography` has an associated type `L`, called it's location set; this is the set of `ChoreographyLocation`s that the `Choreography` can operate on. To build a location set, you can use the macro `LocationSet!`.
 
 ## Choreographic Operators
 
@@ -36,7 +36,7 @@ The `locally` operator is used to perform a computation at a single location. It
 #
 # struct HelloWorldChoreography;
 # impl Choreography for HelloWorldChoreography {
-#     type L = hlist!(Alice);
+#     type L = LocationSet!(Alice);
 #     fn run(self, op: &impl ChoreoOp<Self::L>) {
 op.locally(Alice, |_| {
     println!("Hello, World!");
@@ -52,7 +52,7 @@ The closure can return a value to create a located value. Located values are val
 #
 # struct HelloWorldChoreography;
 # impl Choreography for HelloWorldChoreography {
-#     type L = hlist!(Alice);
+#     type L = LocationSet!(Alice);
 #     fn run(self, op: &impl ChoreoOp<Self::L>) {
 // This value is only available at Alice
 let num_at_alice: Located<i32, Alice> = op.locally(Alice, |_| {
@@ -69,7 +69,7 @@ The computation closure takes `Unwrapper`. Using the `Unwrapper`, you can get a 
 #
 # struct HelloWorldChoreography;
 # impl Choreography for HelloWorldChoreography {
-#     type L = hlist!(Alice);
+#     type L = LocationSet!(Alice);
 #     fn run(self, op: &impl ChoreoOp<Self::L>) {
 let num_at_alice: Located<i32, Alice> = op.locally(Alice, |_| {
     42
@@ -90,7 +90,7 @@ Note that you can unwrap a located value only at the location where the located 
 #
 # struct HelloWorldChoreography;
 # impl Choreography for HelloWorldChoreography {
-#     type L = hlist!(Alice, Bob);
+#     type L = LocationSet!(Alice, Bob);
 #     fn run(self, op: &impl ChoreoOp<Self::L>) {
 // This code will fail to compile
 let num_at_alice = op.locally(Alice, |_| { 42 });
@@ -113,7 +113,7 @@ The `comm` operator is used to perform a communication between two locations. It
 #
 # struct HelloWorldChoreography;
 # impl Choreography for HelloWorldChoreography {
-#     type L = hlist!(Alice, Bob);
+#     type L = LocationSet!(Alice, Bob);
 #     fn run(self, op: &impl ChoreoOp<Self::L>) {
 // This value is only available at Alice
 let num_at_alice: Located<i32, Alice> = op.locally(Alice, |_| {
@@ -139,7 +139,7 @@ The `broadcast` operator is used to perform a broadcast from a single location t
 #
 # struct HelloWorldChoreography;
 # impl Choreography for HelloWorldChoreography {
-#     type L = hlist!(Alice);
+#     type L = LocationSet!(Alice);
 #     fn run(self, op: &impl ChoreoOp<Self::L>) {
 // This value is only available at Alice
 let num_at_alice: Located<i32, Alice> = op.locally(Alice, |_| {
@@ -173,7 +173,7 @@ You'll get a compile error if you try to work with a `ChoreographyLocation` that
 # // 2. Implement the `Choreography` trait
 // ...
 impl Choreography for HelloWorldChoreography {
-    type L = hlist!(Alice);
+    type L = LocationSet!(Alice);
     fn run(self, op: &impl ChoreoOp<Self::L>) {
         // this will fail
         op.locally(Bob, |_| {

--- a/chorus_book/src/guide-colocally.md
+++ b/chorus_book/src/guide-colocally.md
@@ -20,7 +20,7 @@ This protocol can be implemented as follows:
 struct DemoChoreography;
 
 impl Choreography for DemoChoreography {
-    type L = hlist!(Alice, Bob, Carol);
+    type L = LocationSet!(Alice, Bob, Carol);
     fn run(self, op: &impl ChoreoOp<Self::L>) {
         let x_at_alice = op.locally(Alice, |_| {
             get_random_number()
@@ -52,7 +52,7 @@ struct BobCarolChoreography {
     x_at_bob: Located<u32, Bob>,
 };
 impl Choreography for BobCarolChoreography {
-    type L = hlist!(Bob, Carol);
+    type L = LocationSet!(Bob, Carol);
     fn run(self, op: &impl ChoreoOp<Self::L>) {
         let is_even_at_bob: Located<bool, Bob> = op.locally(Bob, |un| {
             let x = un.unwrap(&self.x_at_bob);
@@ -81,7 +81,7 @@ Notice that `BobCarolChoreography` only describes the behavior of Bob and Carol 
 #     x_at_bob: Located<u32, Bob>,
 # };
 # impl Choreography for BobCarolChoreography {
-#     type L = hlist!(Bob, Carol);
+#     type L = LocationSet!(Bob, Carol);
 #     fn run(self, op: &impl ChoreoOp<Self::L>) {
 #         let is_even_at_bob: Located<bool, Bob> = op.locally(Bob, |un| {
 #             let x = un.unwrap(&self.x_at_bob);
@@ -99,7 +99,7 @@ Notice that `BobCarolChoreography` only describes the behavior of Bob and Carol 
 # }
 struct MainChoreography;
 impl Choreography for MainChoreography {
-    type L = hlist!(Alice, Bob, Carol);
+    type L = LocationSet!(Alice, Bob, Carol);
     fn run(self, op: &impl ChoreoOp<Self::L>) {
         let x_at_alice = op.locally(Alice, |_| {
             get_random_number()
@@ -135,7 +135,7 @@ struct BobCarolChoreography {
 };
 
 impl Choreography<BobCarolResult> for BobCarolChoreography {
-    type L = hlist!(Bob, Carol);
+    type L = LocationSet!(Bob, Carol);
     fn run(self, op: &impl ChoreoOp<Self::L>) -> BobCarolResult {
         let is_even_at_bob: Located<bool, Bob> = op.locally(Bob, |un| {
             let x = un.unwrap(&self.x_at_bob);
@@ -159,7 +159,7 @@ impl Choreography<BobCarolResult> for BobCarolChoreography {
 struct MainChoreography;
 
 impl Choreography for MainChoreography {
-    type L = hlist!(Alice, Bob, Carol);
+    type L = LocationSet!(Alice, Bob, Carol);
     fn run(self, op: &impl ChoreoOp<Self::L>) {
         let x_at_alice = op.locally(Alice, |_| {
             get_random_number()

--- a/chorus_book/src/guide-higher-order-choreography.md
+++ b/chorus_book/src/guide-higher-order-choreography.md
@@ -22,8 +22,8 @@ When you implement the `Choreography` trait, you have access to the `sub_choreo`
 # struct HigherOrderChoreography<C: Choreography> {
 #     sub_choreo: C,
 # };
-impl<C: Choreography<(), L = hlist!(Alice, Bob)>> Choreography for HigherOrderChoreography<C> {
-    type L = hlist!(Alice, Bob);
+impl<C: Choreography<(), L = LocationSet!(Alice, Bob)>> Choreography for HigherOrderChoreography<C> {
+    type L = LocationSet!(Alice, Bob);
     fn run(self, op: &impl ChoreoOp<Self::L>) {
         op.call(self.sub_choreo);
     }
@@ -46,8 +46,8 @@ struct HigherOrderChoreography<C: Choreography<Located<bool, Alice>> + SubChoreo
     _marker: PhantomData<C>,
 };
 
-impl<C: Choreography<Located<bool, Alice>, L = hlist!(Alice)> + SubChoreography> Choreography for HigherOrderChoreography<C> {
-    type L = hlist!(Alice);
+impl<C: Choreography<Located<bool, Alice>, L = LocationSet!(Alice)> + SubChoreography> Choreography for HigherOrderChoreography<C> {
+    type L = LocationSet!(Alice);
     fn run(self, op: &impl ChoreoOp<Self::L>) {
         let num_at_alice = op.locally(Alice, |_| {
             42

--- a/chorus_book/src/guide-input-and-output.md
+++ b/chorus_book/src/guide-input-and-output.md
@@ -42,7 +42,8 @@ You can construct an instance of the choreography with the input and pass it to 
 let choreo = DemoChoreography {
     input: "World".to_string(),
 };
-let projector = ProjectorForAL::<hlist!(Alice)>::new(Alice, transport);
+type AL = hlist!(Alice);
+let projector = projector!(AL, Alice, transport);
 projector.epp_and_run(choreo);
 ```
 
@@ -92,7 +93,8 @@ To run the sample choreography above at Alice, we use the `local` method to cons
 #         });
 #     }
 # }
-let projector_for_alice = ProjectorForAL::<hlist!(Alice)>::new(Alice, transport);
+type AL = hlist!(Alice);
+let projector_for_alice = projector!(AL, Alice, transport);
 // Because the target of the projector is Alice, the located value is available at Alice.
 let string_at_alice: Located<String, Alice> = projector_for_alice.local("Hello, World!".to_string());
 // Instantiate the choreography with the located value
@@ -119,7 +121,8 @@ For Bob, we use the `remote` method to construct the located value.
 #         });
 #     }
 # }
-let projector_for_bob = ProjectorForAL::<hlist!(Alice, Bob)>::new(Bob, transport);
+type AL = hlist!(Alice, Bob);
+let projector_for_bob = projector!(AL, Bob, transport);
 // Construct a remote located value at Alice. The actual value is not required.
 let string_at_alice = projector_for_bob.remote(Alice);
 // Instantiate the choreography with the located value
@@ -160,7 +163,8 @@ impl Choreography<String> for DemoChoreography {
 #     }
 # }
 let choreo = DemoChoreography;
-let projector = ProjectorForAL::<hlist!(Alice)>::new(Alice, transport);
+type AL = hlist!(Alice);
+let projector = projector!(AL, Alice, transport);
 let output = projector.epp_and_run(choreo);
 assert_eq!(output, "Hello, World!".to_string());
 ```
@@ -182,7 +186,8 @@ impl Choreography<Located<String, Alice>> for DemoChoreography {
     }
 }
 
-let projector = ProjectorForAL::<hlist!(Alice)>::new(Alice, transport);
+type AL = hlist!(Alice);
+let projector = projector!(AL, Alice, transport);
 let output = projector.epp_and_run(DemoChoreography);
 let string_at_alice = projector.unwrap(output);
 assert_eq!(string_at_alice, "Hello, World!".to_string());

--- a/chorus_book/src/guide-input-and-output.md
+++ b/chorus_book/src/guide-input-and-output.md
@@ -33,7 +33,7 @@ You can construct an instance of the choreography with the input and pass it to 
 #     input: String,
 # }
 # impl Choreography for DemoChoreography {
-#     type L = hlist!();
+#     type L = hlist!(Alice);
 #     fn run(self, op: &impl ChoreoOp<Self::L>) {
 #         println!("Input: {}", self.input);
 #     }
@@ -42,7 +42,7 @@ You can construct an instance of the choreography with the input and pass it to 
 let choreo = DemoChoreography {
     input: "World".to_string(),
 };
-let projector = Projector::new(Alice, transport);
+let projector = ProjectorForAL::<hlist!(Alice)>::new(Alice, transport);
 projector.epp_and_run(choreo);
 ```
 
@@ -92,7 +92,7 @@ To run the sample choreography above at Alice, we use the `local` method to cons
 #         });
 #     }
 # }
-let projector_for_alice = Projector::new(Alice, transport);
+let projector_for_alice = ProjectorForAL::<hlist!(Alice)>::new(Alice, transport);
 // Because the target of the projector is Alice, the located value is available at Alice.
 let string_at_alice: Located<String, Alice> = projector_for_alice.local("Hello, World!".to_string());
 // Instantiate the choreography with the located value
@@ -111,7 +111,7 @@ For Bob, we use the `remote` method to construct the located value.
 # }
 #
 # impl Choreography for DemoChoreography {
-#     type L = hlist!(Alice);
+#     type L = hlist!(Alice, Bob);
 #     fn run(self, op: &impl ChoreoOp<Self::L>) {
 #         op.locally(Alice, |un| {
 #             let input = un.unwrap(&self.input);
@@ -119,7 +119,7 @@ For Bob, we use the `remote` method to construct the located value.
 #         });
 #     }
 # }
-let projector_for_bob = Projector::new(Bob, transport);
+let projector_for_bob = ProjectorForAL::<hlist!(Alice, Bob)>::new(Bob, transport);
 // Construct a remote located value at Alice. The actual value is not required.
 let string_at_alice = projector_for_bob.remote(Alice);
 // Instantiate the choreography with the located value
@@ -160,7 +160,7 @@ impl Choreography<String> for DemoChoreography {
 #     }
 # }
 let choreo = DemoChoreography;
-let projector = Projector::new(Alice, transport);
+let projector = ProjectorForAL::<hlist!(Alice)>::new(Alice, transport);
 let output = projector.epp_and_run(choreo);
 assert_eq!(output, "Hello, World!".to_string());
 ```
@@ -182,7 +182,7 @@ impl Choreography<Located<String, Alice>> for DemoChoreography {
     }
 }
 
-let projector = Projector::new(Alice, transport);
+let projector = ProjectorForAL::<hlist!(Alice)>::new(Alice, transport);
 let output = projector.epp_and_run(DemoChoreography);
 let string_at_alice = projector.unwrap(output);
 assert_eq!(string_at_alice, "Hello, World!".to_string());

--- a/chorus_book/src/guide-input-and-output.md
+++ b/chorus_book/src/guide-input-and-output.md
@@ -18,7 +18,7 @@ struct DemoChoreography {
 }
 
 impl Choreography for DemoChoreography {
-    type L = hlist!();
+    type L = LocationSet!();
     fn run(self, op: &impl ChoreoOp<Self::L>) {
         println!("Input: {}", self.input);
     }
@@ -33,7 +33,7 @@ You can construct an instance of the choreography with the input and pass it to 
 #     input: String,
 # }
 # impl Choreography for DemoChoreography {
-#     type L = hlist!(Alice);
+#     type L = LocationSet!(Alice);
 #     fn run(self, op: &impl ChoreoOp<Self::L>) {
 #         println!("Input: {}", self.input);
 #     }
@@ -42,8 +42,8 @@ You can construct an instance of the choreography with the input and pass it to 
 let choreo = DemoChoreography {
     input: "World".to_string(),
 };
-type AL = hlist!(Alice);
-let projector = projector!(AL, Alice, transport);
+
+let projector = projector!(LocationSet!(Alice), Alice, transport);
 projector.epp_and_run(choreo);
 ```
 
@@ -58,7 +58,7 @@ struct DemoChoreography {
 }
 
 impl Choreography for DemoChoreography {
-    type L = hlist!(Alice);
+    type L = LocationSet!(Alice);
     fn run(self, op: &impl ChoreoOp<Self::L>) {
         op.locally(Alice, |un| {
             let input = un.unwrap(&self.input);
@@ -85,7 +85,7 @@ To run the sample choreography above at Alice, we use the `local` method to cons
 # }
 #
 # impl Choreography for DemoChoreography {
-#     type L = hlist!(Alice);
+#     type L = LocationSet!(Alice);
 #     fn run(self, op: &impl ChoreoOp<Self::L>) {
 #         op.locally(Alice, |un| {
 #             let input = un.unwrap(&self.input);
@@ -93,8 +93,7 @@ To run the sample choreography above at Alice, we use the `local` method to cons
 #         });
 #     }
 # }
-type AL = hlist!(Alice);
-let projector_for_alice = projector!(AL, Alice, transport);
+let projector_for_alice = projector!(LocationSet!(Alice), Alice, transport);
 // Because the target of the projector is Alice, the located value is available at Alice.
 let string_at_alice: Located<String, Alice> = projector_for_alice.local("Hello, World!".to_string());
 // Instantiate the choreography with the located value
@@ -113,7 +112,7 @@ For Bob, we use the `remote` method to construct the located value.
 # }
 #
 # impl Choreography for DemoChoreography {
-#     type L = hlist!(Alice, Bob);
+#     type L = LocationSet!(Alice, Bob);
 #     fn run(self, op: &impl ChoreoOp<Self::L>) {
 #         op.locally(Alice, |un| {
 #             let input = un.unwrap(&self.input);
@@ -121,8 +120,7 @@ For Bob, we use the `remote` method to construct the located value.
 #         });
 #     }
 # }
-type AL = hlist!(Alice, Bob);
-let projector_for_bob = projector!(AL, Bob, transport);
+let projector_for_bob = projector!(LocationSet!(Alice, Bob), Bob, transport);
 // Construct a remote located value at Alice. The actual value is not required.
 let string_at_alice = projector_for_bob.remote(Alice);
 // Instantiate the choreography with the located value
@@ -143,7 +141,7 @@ To do so, we specify the output type to the `Choreography` trait and return the 
 struct DemoChoreography;
 
 impl Choreography<String> for DemoChoreography {
-    type L = hlist!();
+    type L = LocationSet!();
     fn run(self, op: &impl ChoreoOp<Self::L>) -> String {
         "Hello, World!".to_string()
     }
@@ -157,14 +155,13 @@ impl Choreography<String> for DemoChoreography {
 # struct DemoChoreography;
 #
 # impl Choreography<String> for DemoChoreography {
-#     type L = hlist!(Alice);
+#     type L = LocationSet!(Alice);
 #     fn run(self, op: &impl ChoreoOp<Self::L>) -> String {
 #         "Hello, World!".to_string()
 #     }
 # }
 let choreo = DemoChoreography;
-type AL = hlist!(Alice);
-let projector = projector!(AL, Alice, transport);
+let projector = projector!(LocationSet!(Alice), Alice, transport);
 let output = projector.epp_and_run(choreo);
 assert_eq!(output, "Hello, World!".to_string());
 ```
@@ -178,7 +175,7 @@ You can use the `Located<V, L1>` as a return type of the `run` method to return 
 struct DemoChoreography;
 
 impl Choreography<Located<String, Alice>> for DemoChoreography {
-    type L = hlist!(Alice);
+    type L = LocationSet!(Alice);
     fn run(self, op: &impl ChoreoOp<Self::L>) -> Located<String, Alice> {
         op.locally(Alice, |_| {
             "Hello, World!".to_string()
@@ -186,8 +183,7 @@ impl Choreography<Located<String, Alice>> for DemoChoreography {
     }
 }
 
-type AL = hlist!(Alice);
-let projector = projector!(AL, Alice, transport);
+let projector = projector!(LocationSet!(Alice), Alice, transport);
 let output = projector.epp_and_run(DemoChoreography);
 let string_at_alice = projector.unwrap(output);
 assert_eq!(string_at_alice, "Hello, World!".to_string());

--- a/chorus_book/src/guide-location-polymorphism.md
+++ b/chorus_book/src/guide-location-polymorphism.md
@@ -11,7 +11,7 @@ struct LocationPolymorphicChoreography<L1: ChoreographyLocation> {
 }
 
 impl<L1: ChoreographyLocation> Choreography for LocationPolymorphicChoreography<L1> {
-    type L = hlist!(L1);
+    type L = LocationSet!(L1);
     fn run(self, op: &impl ChoreoOp<Self::L>) {
         op.locally(self.location, |_| {
             println!("Hello, World!");

--- a/chorus_book/src/guide-projector.md
+++ b/chorus_book/src/guide-projector.md
@@ -4,7 +4,7 @@ Projector is responsible for performing the end-point projection and executing t
 
 ## Creating a Projector
 
-To create a `Projector`, you need to provide the location and the transport.
+To create a `Projector`, you need to provide the set of locations it can work with, the target location, and the transport.
 
 ```rust
 # extern crate chorus_lib;
@@ -52,3 +52,30 @@ projector.epp_and_run(HelloWorldChoreography);
 ```
 
 If the choreography has a return value, the `epp_and_run` method will return the value. We will discuss the return values in the [Input and Output](./guide-input-and-output.md) section.
+
+### Note on the available location set of the Choreography
+
+Keep in mind that when calling `epp_and_run`, you will get a compile error if the set of available locations of the `Choreography` is not a subset of the available locations of the `Projector`. In other words, the `Projector` should be allowed to do end-point projection into every `ChoreographyLocation` there is in the `Choreography`. So this will fail:
+
+```rust, compile_fail
+# extern crate chorus_lib;
+# use chorus_lib::transport::local::LocalTransport;
+# use chorus_lib::core::{ChoreographyLocation, Projector, Choreography, ChoreoOp};
+# use chorus_lib::{hlist, projector};
+# let transport = LocalTransport::from(&[Alice::name(), Bob::name()]);
+# #[derive(ChoreographyLocation)]
+# struct Alice;
+# #[derive(ChoreographyLocation)]
+# struct Bob;
+struct HelloWorldChoreography;
+impl Choreography for HelloWorldChoreography {
+     type L = hlist!(Alice, Bob);
+     fn run(self, op: &impl ChoreoOp<Self::L>) {
+     }
+}
+
+
+type AL = hlist!(Alice);
+let projector = projector!(AL, Alice, transport);
+projector.epp_and_run(HelloWorldChoreography);
+```

--- a/chorus_book/src/guide-projector.md
+++ b/chorus_book/src/guide-projector.md
@@ -4,7 +4,7 @@ Projector is responsible for performing the end-point projection and executing t
 
 ## Creating a Projector
 
-To create a `Projector`, you need to provide the set of locations it can work with, the target location, and the transport.
+To create a `Projector`, you need to provide the set of locations it can work with, the target location, and the transport. You should use the `projector!` macro instead of directly instantiating a Projector.
 
 ```rust
 # extern crate chorus_lib;
@@ -21,7 +21,7 @@ To create a `Projector`, you need to provide the set of locations it can work wi
 let projector = projector!(LocationSet!(Alice, Bob), Alice, transport);
 ```
 
-Notice that the `Projector` is parameterized by the location type. You will need one projector for each location to execute choreography.
+Notice that the `Projector` is parameterized by its target location type. You will need one projector for each location to execute choreography.
 
 ## Executing a Choreography
 

--- a/chorus_book/src/guide-projector.md
+++ b/chorus_book/src/guide-projector.md
@@ -9,14 +9,15 @@ To create a `Projector`, you need to provide the location and the transport.
 ```rust
 # extern crate chorus_lib;
 # use chorus_lib::transport::local::LocalTransport;
-# use chorus_lib::core::{ChoreographyLocation, Projector};
+# use chorus_lib::core::{ChoreographyLocation, ProjectorForAL};
+# use chorus_lib::hlist;
 # let transport = LocalTransport::from(&[Alice::name(), Bob::name()]);
 # #[derive(ChoreographyLocation)]
 # struct Alice;
 # #[derive(ChoreographyLocation)]
 # struct Bob;
 #
-let projector = Projector::new(Alice, transport);
+let projector = ProjectorForAL::<hlist!(Alice, Bob)>::new(Alice, transport);
 ```
 
 Notice that the `Projector` is parameterized by the location type. You will need one projector for each location to execute choreography.
@@ -28,7 +29,8 @@ To execute a choreography, you need to call the `epp_and_run` method on the `Pro
 ```rust
 # extern crate chorus_lib;
 # use chorus_lib::transport::local::LocalTransport;
-# use chorus_lib::core::{ChoreographyLocation, Projector, Choreography, ChoreoOp, HNil};
+# use chorus_lib::core::{ChoreographyLocation, ProjectorForAL, Choreography, ChoreoOp};
+# use chorus_lib::hlist;
 # let transport = LocalTransport::from(&[Alice::name(), Bob::name()]);
 # #[derive(ChoreographyLocation)]
 # struct Alice;
@@ -36,12 +38,12 @@ To execute a choreography, you need to call the `epp_and_run` method on the `Pro
 # struct Bob;
 # struct HelloWorldChoreography;
 # impl Choreography for HelloWorldChoreography {
-#     type L = HNil;
+#     type L = hlist!(Alice);
 #     fn run(self, op: &impl ChoreoOp<Self::L>) {
 #     }
 # }
 #
-# let projector = Projector::new(Alice, transport);
+# let projector = ProjectorForAL::<hlist!(Alice)>::new(Alice, transport);
 projector.epp_and_run(HelloWorldChoreography);
 ```
 

--- a/chorus_book/src/guide-projector.md
+++ b/chorus_book/src/guide-projector.md
@@ -10,7 +10,7 @@ To create a `Projector`, you need to provide the set of locations it can work wi
 # extern crate chorus_lib;
 # use chorus_lib::transport::local::LocalTransport;
 # use chorus_lib::core::{ChoreographyLocation, Projector};
-# use chorus_lib::{hlist, projector};
+# use chorus_lib::{LocationSet, projector};
 # let transport = LocalTransport::from(&[Alice::name(), Bob::name()]);
 # #[derive(ChoreographyLocation)]
 # struct Alice;
@@ -18,8 +18,7 @@ To create a `Projector`, you need to provide the set of locations it can work wi
 # struct Bob;
 #
 
-type AL = hlist!(Alice, Bob);
-let projector = projector!(AL, Alice, transport);
+let projector = projector!(LocationSet!(Alice, Bob), Alice, transport);
 ```
 
 Notice that the `Projector` is parameterized by the location type. You will need one projector for each location to execute choreography.
@@ -32,7 +31,7 @@ To execute a choreography, you need to call the `epp_and_run` method on the `Pro
 # extern crate chorus_lib;
 # use chorus_lib::transport::local::LocalTransport;
 # use chorus_lib::core::{ChoreographyLocation, Projector, Choreography, ChoreoOp};
-# use chorus_lib::{hlist, projector};
+# use chorus_lib::{LocationSet, projector};
 # let transport = LocalTransport::from(&[Alice::name(), Bob::name()]);
 # #[derive(ChoreographyLocation)]
 # struct Alice;
@@ -40,28 +39,27 @@ To execute a choreography, you need to call the `epp_and_run` method on the `Pro
 # struct Bob;
 # struct HelloWorldChoreography;
 # impl Choreography for HelloWorldChoreography {
-#     type L = hlist!(Alice);
+#     type L = LocationSet!(Alice);
 #     fn run(self, op: &impl ChoreoOp<Self::L>) {
 #     }
 # }
 #
 
-# type AL = hlist!(Alice);
-# let projector = projector!(AL, Alice, transport);
+# let projector = projector!(LocationSet!(Alice), Alice, transport);
 projector.epp_and_run(HelloWorldChoreography);
 ```
 
 If the choreography has a return value, the `epp_and_run` method will return the value. We will discuss the return values in the [Input and Output](./guide-input-and-output.md) section.
 
-### Note on the available location set of the Choreography
+### Note on the location set of the Choreography
 
-Keep in mind that when calling `epp_and_run`, you will get a compile error if the set of available locations of the `Choreography` is not a subset of the available locations of the `Projector`. In other words, the `Projector` should be allowed to do end-point projection into every `ChoreographyLocation` there is in the `Choreography`. So this will fail:
+Keep in mind that when calling `epp_and_run`, you will get a compile error if the location set of the `Choreography` is not a subset of the location set of the `Projector`. In other words, the `Projector` should be allowed to do end-point projection into every `ChoreographyLocation`  that `Choreography` can talk about. So this will fail:
 
 ```rust, compile_fail
 # extern crate chorus_lib;
 # use chorus_lib::transport::local::LocalTransport;
 # use chorus_lib::core::{ChoreographyLocation, Projector, Choreography, ChoreoOp};
-# use chorus_lib::{hlist, projector};
+# use chorus_lib::{LocationSet, projector};
 # let transport = LocalTransport::from(&[Alice::name(), Bob::name()]);
 # #[derive(ChoreographyLocation)]
 # struct Alice;
@@ -69,13 +67,11 @@ Keep in mind that when calling `epp_and_run`, you will get a compile error if th
 # struct Bob;
 struct HelloWorldChoreography;
 impl Choreography for HelloWorldChoreography {
-     type L = hlist!(Alice, Bob);
+     type L = LocationSet!(Alice, Bob);
      fn run(self, op: &impl ChoreoOp<Self::L>) {
      }
 }
 
-
-type AL = hlist!(Alice);
-let projector = projector!(AL, Alice, transport);
+let projector = projector!(LocationSet!(Alice), Alice, transport);
 projector.epp_and_run(HelloWorldChoreography);
 ```

--- a/chorus_book/src/guide-projector.md
+++ b/chorus_book/src/guide-projector.md
@@ -9,15 +9,17 @@ To create a `Projector`, you need to provide the location and the transport.
 ```rust
 # extern crate chorus_lib;
 # use chorus_lib::transport::local::LocalTransport;
-# use chorus_lib::core::{ChoreographyLocation, ProjectorForAL};
-# use chorus_lib::hlist;
+# use chorus_lib::core::{ChoreographyLocation, Projector};
+# use chorus_lib::{hlist, projector};
 # let transport = LocalTransport::from(&[Alice::name(), Bob::name()]);
 # #[derive(ChoreographyLocation)]
 # struct Alice;
 # #[derive(ChoreographyLocation)]
 # struct Bob;
 #
-let projector = ProjectorForAL::<hlist!(Alice, Bob)>::new(Alice, transport);
+
+type AL = hlist!(Alice, Bob);
+let projector = projector!(AL, Alice, transport);
 ```
 
 Notice that the `Projector` is parameterized by the location type. You will need one projector for each location to execute choreography.
@@ -29,8 +31,8 @@ To execute a choreography, you need to call the `epp_and_run` method on the `Pro
 ```rust
 # extern crate chorus_lib;
 # use chorus_lib::transport::local::LocalTransport;
-# use chorus_lib::core::{ChoreographyLocation, ProjectorForAL, Choreography, ChoreoOp};
-# use chorus_lib::hlist;
+# use chorus_lib::core::{ChoreographyLocation, Projector, Choreography, ChoreoOp};
+# use chorus_lib::{hlist, projector};
 # let transport = LocalTransport::from(&[Alice::name(), Bob::name()]);
 # #[derive(ChoreographyLocation)]
 # struct Alice;
@@ -43,7 +45,9 @@ To execute a choreography, you need to call the `epp_and_run` method on the `Pro
 #     }
 # }
 #
-# let projector = ProjectorForAL::<hlist!(Alice)>::new(Alice, transport);
+
+# type AL = hlist!(Alice);
+# let projector = projector!(AL, Alice, transport);
 projector.epp_and_run(HelloWorldChoreography);
 ```
 

--- a/chorus_book/src/guide-runner.md
+++ b/chorus_book/src/guide-runner.md
@@ -8,7 +8,7 @@ To use `Runner`, construct an instance using the `new` constructor, and then cal
 {{#include ./header.txt}}
 # struct DemoChoreography;
 # impl Choreography for DemoChoreography {
-#     type L = hlist!();
+#     type L = LocationSet!();
 #     fn run(self, op: &impl ChoreoOp<Self::L>) {
 #     }
 # }
@@ -27,7 +27,7 @@ struct SumChoreography {
     y_at_bob: Located<u32, Bob>,
 }
 impl Choreography<Located<u32, Carol>> for SumChoreography {
-    type L = hlist!(Alice, Bob, Carol);
+    type L = LocationSet!(Alice, Bob, Carol);
     fn run(self, op: &impl ChoreoOp<Self::L>) -> Located<u32, Carol> {
         let x_at_carol = op.comm(Alice, Carol, &self.x_at_alice);
         let y_at_carol = op.comm(Bob, Carol, &self.y_at_bob);

--- a/chorus_book/src/guide-transport.md
+++ b/chorus_book/src/guide-transport.md
@@ -25,8 +25,8 @@ Because of the nature of the `Local` transport, you must use the same `LocalTran
 # extern crate chorus_lib;
 # use chorus_lib::transport::local::LocalTransport;
 # use std::thread;
-# use chorus_lib::core::{ChoreographyLocation, ChoreoOp, Choreography, ProjectorForAL};
-# use chorus_lib::hlist;
+# use chorus_lib::core::{ChoreographyLocation, ChoreoOp, Choreography, Projector};
+# use chorus_lib::{hlist, projector};
 # #[derive(ChoreographyLocation)]
 # struct Alice;
 # #[derive(ChoreographyLocation)]
@@ -47,7 +47,7 @@ let transport = LocalTransport::from(&[Alice::name(), Bob::name()]);
     // create a clone for Alice
     let transport = transport.clone();
     handles.push(thread::spawn(move || {
-        let p = ProjectorForAL::<AL>::new(Alice, transport);
+        let p = projector!(AL, Alice, transport);
         p.epp_and_run(HelloWorldChoreography);
     }));
 }
@@ -55,7 +55,7 @@ let transport = LocalTransport::from(&[Alice::name(), Bob::name()]);
     // create another for Bob
     let transport = transport.clone();
     handles.push(thread::spawn(move || {
-        let p = ProjectorForAL::<AL>::new(Bob, transport);
+        let p = projector!(AL, Bob, transport);
         p.epp_and_run(HelloWorldChoreography);
     }));
 }

--- a/chorus_book/src/guide-transport.md
+++ b/chorus_book/src/guide-transport.md
@@ -25,24 +25,29 @@ Because of the nature of the `Local` transport, you must use the same `LocalTran
 # extern crate chorus_lib;
 # use chorus_lib::transport::local::LocalTransport;
 # use std::thread;
-# use chorus_lib::core::{ChoreographyLocation, ChoreoOp, Choreography, Projector, HNil};
+# use chorus_lib::core::{ChoreographyLocation, ChoreoOp, Choreography, ProjectorForAL};
+# use chorus_lib::hlist;
 # #[derive(ChoreographyLocation)]
 # struct Alice;
 # #[derive(ChoreographyLocation)]
 # struct Bob;
 # struct HelloWorldChoreography;
 # impl Choreography for HelloWorldChoreography {
-#     type L = HNil;
+#     type L = hlist!(Alice, Bob);
 #     fn run(self, op: &impl ChoreoOp<Self::L>) {
 #     }
 # }
+
+// Crate available locations for Projector
+type AL = hlist!(Alice, Bob);
+
 let mut handles: Vec<thread::JoinHandle<()>> = Vec::new();
 let transport = LocalTransport::from(&[Alice::name(), Bob::name()]);
 {
     // create a clone for Alice
     let transport = transport.clone();
     handles.push(thread::spawn(move || {
-        let p = Projector::new(Alice, transport);
+        let p = ProjectorForAL::<AL>::new(Alice, transport);
         p.epp_and_run(HelloWorldChoreography);
     }));
 }
@@ -50,7 +55,7 @@ let transport = LocalTransport::from(&[Alice::name(), Bob::name()]);
     // create another for Bob
     let transport = transport.clone();
     handles.push(thread::spawn(move || {
-        let p = Projector::new(Bob, transport);
+        let p = ProjectorForAL::<AL>::new(Bob, transport);
         p.epp_and_run(HelloWorldChoreography);
     }));
 }

--- a/chorus_book/src/guide-transport.md
+++ b/chorus_book/src/guide-transport.md
@@ -26,20 +26,18 @@ Because of the nature of the `Local` transport, you must use the same `LocalTran
 # use chorus_lib::transport::local::LocalTransport;
 # use std::thread;
 # use chorus_lib::core::{ChoreographyLocation, ChoreoOp, Choreography, Projector};
-# use chorus_lib::{hlist, projector};
+# use chorus_lib::{LocationSet, projector};
 # #[derive(ChoreographyLocation)]
 # struct Alice;
 # #[derive(ChoreographyLocation)]
 # struct Bob;
 # struct HelloWorldChoreography;
 # impl Choreography for HelloWorldChoreography {
-#     type L = hlist!(Alice, Bob);
+#     type L = LocationSet!(Alice, Bob);
 #     fn run(self, op: &impl ChoreoOp<Self::L>) {
 #     }
 # }
 
-// Crate available locations for Projector
-type AL = hlist!(Alice, Bob);
 
 let mut handles: Vec<thread::JoinHandle<()>> = Vec::new();
 let transport = LocalTransport::from(&[Alice::name(), Bob::name()]);
@@ -47,7 +45,7 @@ let transport = LocalTransport::from(&[Alice::name(), Bob::name()]);
     // create a clone for Alice
     let transport = transport.clone();
     handles.push(thread::spawn(move || {
-        let p = projector!(AL, Alice, transport);
+        let p = projector!(LocationSet!(Alice, Bob), Alice, transport);
         p.epp_and_run(HelloWorldChoreography);
     }));
 }
@@ -55,7 +53,7 @@ let transport = LocalTransport::from(&[Alice::name(), Bob::name()]);
     // create another for Bob
     let transport = transport.clone();
     handles.push(thread::spawn(move || {
-        let p = projector!(AL, Bob, transport);
+        let p = projector!(LocationSet!(Alice, Bob), Bob, transport);
         p.epp_and_run(HelloWorldChoreography);
     }));
 }

--- a/chorus_book/src/header.txt
+++ b/chorus_book/src/header.txt
@@ -1,5 +1,5 @@
 # extern crate chorus_lib;
-# use chorus_lib::core::{ChoreoOp, Choreography, ChoreographyLocation, Projector, Located, Superposition, Runner};
+# use chorus_lib::core::{ChoreoOp, Choreography, ChoreographyLocation, ProjectorForAL, Located, Superposition, Runner};
 # use chorus_lib::transport::local::LocalTransport;
 # use chorus_lib::hlist;
 # #[derive(ChoreographyLocation)]

--- a/chorus_book/src/header.txt
+++ b/chorus_book/src/header.txt
@@ -1,7 +1,7 @@
 # extern crate chorus_lib;
 # use chorus_lib::core::{ChoreoOp, Choreography, ChoreographyLocation, Projector, Located, Superposition, Runner};
 # use chorus_lib::transport::local::LocalTransport;
-# use chorus_lib::{hlist, projector};
+# use chorus_lib::{LocationSet, projector};
 # #[derive(ChoreographyLocation)]
 # struct Alice;
 # #[derive(ChoreographyLocation)]

--- a/chorus_book/src/header.txt
+++ b/chorus_book/src/header.txt
@@ -1,7 +1,7 @@
 # extern crate chorus_lib;
-# use chorus_lib::core::{ChoreoOp, Choreography, ChoreographyLocation, ProjectorForAL, Located, Superposition, Runner};
+# use chorus_lib::core::{ChoreoOp, Choreography, ChoreographyLocation, Projector, Located, Superposition, Runner};
 # use chorus_lib::transport::local::LocalTransport;
-# use chorus_lib::hlist;
+# use chorus_lib::{hlist, projector};
 # #[derive(ChoreographyLocation)]
 # struct Alice;
 # #[derive(ChoreographyLocation)]

--- a/chorus_lib/examples/bookseller.rs
+++ b/chorus_lib/examples/bookseller.rs
@@ -6,7 +6,7 @@ use std::thread;
 use chorus_lib::hlist;
 use chrono::NaiveDate;
 
-use chorus_lib::core::{ChoreoOp, Choreography, ChoreographyLocation, Projector};
+use chorus_lib::core::{ChoreoOp, Choreography, ChoreographyLocation, ProjectorForAL};
 use chorus_lib::transport::local::LocalTransport;
 
 fn get_book(title: &str) -> Option<(i32, NaiveDate)> {
@@ -74,8 +74,9 @@ impl Choreography for BooksellerChoreography {
 
 fn main() {
     let transport = LocalTransport::from(&[Seller::name(), Buyer::name()]);
-    let seller_projector = Projector::new(Seller, transport.clone());
-    let buyer_projector = Projector::new(Buyer, transport.clone());
+    type AL = hlist!(Buyer, Seller); 
+    let seller_projector = ProjectorForAL::<AL>::new(Seller, transport.clone());
+    let buyer_projector = ProjectorForAL::<AL>::new(Buyer, transport.clone());
 
     let mut handles: Vec<thread::JoinHandle<()>> = Vec::new();
     handles.push(thread::spawn(move || {

--- a/chorus_lib/examples/bookseller.rs
+++ b/chorus_lib/examples/bookseller.rs
@@ -5,9 +5,9 @@ use std::thread;
 
 use chrono::NaiveDate;
 
-use chorus_lib::core::{ChoreoOp, Choreography, ChoreographyLocation, Projector};
+use chorus_lib::core::{ChoreoOp, Choreography, ChoreographyLocation};
 use chorus_lib::transport::local::LocalTransport;
-use chorus_lib::{hlist, projector};
+use chorus_lib::{projector, LocationSet};
 
 fn get_book(title: &str) -> Option<(i32, NaiveDate)> {
     match title.trim() {
@@ -27,7 +27,7 @@ struct Buyer;
 
 struct BooksellerChoreography;
 impl Choreography for BooksellerChoreography {
-    type L = hlist!(Seller, Buyer);
+    type L = LocationSet!(Seller, Buyer);
     fn run(self, op: &impl ChoreoOp<Self::L>) {
         let title_at_buyer = op.locally(Buyer, |_| {
             println!("Enter the title of the book to buy (TAPL or HoTT)");
@@ -74,9 +74,8 @@ impl Choreography for BooksellerChoreography {
 
 fn main() {
     let transport = LocalTransport::from(&[Seller::name(), Buyer::name()]);
-    type AL = hlist!(Buyer, Seller);
-    let seller_projector = projector!(AL, Seller, transport.clone());
-    let buyer_projector = projector!(AL, Buyer, transport.clone());
+    let seller_projector = projector!(LocationSet!(Buyer, Seller), Seller, transport.clone());
+    let buyer_projector = projector!(LocationSet!(Buyer, Seller), Buyer, transport.clone());
 
     let mut handles: Vec<thread::JoinHandle<()>> = Vec::new();
     handles.push(thread::spawn(move || {

--- a/chorus_lib/examples/bookseller.rs
+++ b/chorus_lib/examples/bookseller.rs
@@ -3,10 +3,10 @@ extern crate chorus_lib;
 use std::io;
 use std::thread;
 
-use chorus_lib::hlist;
 use chrono::NaiveDate;
 
-use chorus_lib::core::{ChoreoOp, Choreography, ChoreographyLocation, ProjectorForAL};
+use chorus_lib::{hlist, projector};
+use chorus_lib::core::{ChoreoOp, Choreography, ChoreographyLocation, Projector};
 use chorus_lib::transport::local::LocalTransport;
 
 fn get_book(title: &str) -> Option<(i32, NaiveDate)> {
@@ -75,8 +75,8 @@ impl Choreography for BooksellerChoreography {
 fn main() {
     let transport = LocalTransport::from(&[Seller::name(), Buyer::name()]);
     type AL = hlist!(Buyer, Seller);
-    let seller_projector = ProjectorForAL::<AL>::new(Seller, transport.clone());
-    let buyer_projector = ProjectorForAL::<AL>::new(Buyer, transport.clone());
+    let seller_projector = projector!(AL, Seller, transport.clone());
+    let buyer_projector = projector!(AL, Buyer, transport.clone());
 
     let mut handles: Vec<thread::JoinHandle<()>> = Vec::new();
     handles.push(thread::spawn(move || {

--- a/chorus_lib/examples/bookseller.rs
+++ b/chorus_lib/examples/bookseller.rs
@@ -5,9 +5,9 @@ use std::thread;
 
 use chrono::NaiveDate;
 
-use chorus_lib::{hlist, projector};
 use chorus_lib::core::{ChoreoOp, Choreography, ChoreographyLocation, Projector};
 use chorus_lib::transport::local::LocalTransport;
+use chorus_lib::{hlist, projector};
 
 fn get_book(title: &str) -> Option<(i32, NaiveDate)> {
     match title.trim() {

--- a/chorus_lib/examples/bookseller.rs
+++ b/chorus_lib/examples/bookseller.rs
@@ -74,7 +74,7 @@ impl Choreography for BooksellerChoreography {
 
 fn main() {
     let transport = LocalTransport::from(&[Seller::name(), Buyer::name()]);
-    type AL = hlist!(Buyer, Seller); 
+    type AL = hlist!(Buyer, Seller);
     let seller_projector = ProjectorForAL::<AL>::new(Seller, transport.clone());
     let buyer_projector = ProjectorForAL::<AL>::new(Buyer, transport.clone());
 

--- a/chorus_lib/examples/bookseller2.rs
+++ b/chorus_lib/examples/bookseller2.rs
@@ -3,9 +3,9 @@ extern crate chorus_lib;
 use std::thread;
 use std::{collections::HashMap, sync::Arc};
 
-use chorus_lib::hlist;
+use chorus_lib::{hlist, projector};
 use chorus_lib::{
-    core::{ChoreoOp, Choreography, ChoreographyLocation, Located, ProjectorForAL},
+    core::{ChoreoOp, Choreography, ChoreographyLocation, Located, Projector},
     transport::local::LocalTransport,
 };
 use chrono::NaiveDate;
@@ -144,9 +144,9 @@ fn main() {
 
     type AL = hlist!(Seller, Buyer1, Buyer2);
     let transport = LocalTransport::from(&[Seller::name(), Buyer1::name(), Buyer2::name()]);
-    let seller_projector = Arc::new(ProjectorForAL::<AL>::new(Seller, transport.clone()));
-    let buyer1_projector = Arc::new(ProjectorForAL::<AL>::new(Buyer1, transport.clone()));
-    let buyer2_projector = Arc::new(ProjectorForAL::<AL>::new(Buyer2, transport.clone()));
+    let seller_projector = Arc::new(projector!(AL, Seller, transport.clone()));
+    let buyer1_projector = Arc::new(projector!(AL, Buyer1, transport.clone()));
+    let buyer2_projector = Arc::new(projector!(AL, Buyer2, transport.clone()));
 
     println!("Tries to buy HoTT with one buyer");
     type OneBuyerBooksellerChoreography = BooksellerChoreography<OneBuyerDecider>;

--- a/chorus_lib/examples/bookseller2.rs
+++ b/chorus_lib/examples/bookseller2.rs
@@ -5,7 +5,7 @@ use std::{collections::HashMap, sync::Arc};
 
 use chorus_lib::hlist;
 use chorus_lib::{
-    core::{ChoreoOp, Choreography, ChoreographyLocation, Located, Projector},
+    core::{ChoreoOp, Choreography, ChoreographyLocation, Located, ProjectorForAL},
     transport::local::LocalTransport,
 };
 use chrono::NaiveDate;
@@ -142,10 +142,20 @@ fn main() {
         i
     };
 
+    type AL = hlist!(Seller, Buyer1, Buyer2); 
     let transport = LocalTransport::from(&[Seller::name(), Buyer1::name(), Buyer2::name()]);
-    let seller_projector = Arc::new(Projector::new(Seller, transport.clone()));
-    let buyer1_projector = Arc::new(Projector::new(Buyer1, transport.clone()));
-    let buyer2_projector = Arc::new(Projector::new(Buyer2, transport.clone()));
+    let seller_projector = Arc::new(ProjectorForAL::<AL>::new(
+        Seller,
+        transport.clone()
+    ));
+    let buyer1_projector = Arc::new(ProjectorForAL::<AL>::new(
+        Buyer1,
+        transport.clone(),
+    ));
+    let buyer2_projector = Arc::new(ProjectorForAL::<AL>::new(
+        Buyer2,
+        transport.clone(),
+    ));
 
     println!("Tries to buy HoTT with one buyer");
     type OneBuyerBooksellerChoreography = BooksellerChoreography<OneBuyerDecider>;

--- a/chorus_lib/examples/bookseller2.rs
+++ b/chorus_lib/examples/bookseller2.rs
@@ -3,11 +3,11 @@ extern crate chorus_lib;
 use std::thread;
 use std::{collections::HashMap, sync::Arc};
 
-use chorus_lib::{hlist, projector};
 use chorus_lib::{
     core::{ChoreoOp, Choreography, ChoreographyLocation, Located, Projector},
     transport::local::LocalTransport,
 };
+use chorus_lib::{hlist, projector};
 use chrono::NaiveDate;
 
 #[derive(ChoreographyLocation)]

--- a/chorus_lib/examples/bookseller2.rs
+++ b/chorus_lib/examples/bookseller2.rs
@@ -142,20 +142,11 @@ fn main() {
         i
     };
 
-    type AL = hlist!(Seller, Buyer1, Buyer2); 
+    type AL = hlist!(Seller, Buyer1, Buyer2);
     let transport = LocalTransport::from(&[Seller::name(), Buyer1::name(), Buyer2::name()]);
-    let seller_projector = Arc::new(ProjectorForAL::<AL>::new(
-        Seller,
-        transport.clone()
-    ));
-    let buyer1_projector = Arc::new(ProjectorForAL::<AL>::new(
-        Buyer1,
-        transport.clone(),
-    ));
-    let buyer2_projector = Arc::new(ProjectorForAL::<AL>::new(
-        Buyer2,
-        transport.clone(),
-    ));
+    let seller_projector = Arc::new(ProjectorForAL::<AL>::new(Seller, transport.clone()));
+    let buyer1_projector = Arc::new(ProjectorForAL::<AL>::new(Buyer1, transport.clone()));
+    let buyer2_projector = Arc::new(ProjectorForAL::<AL>::new(Buyer2, transport.clone()));
 
     println!("Tries to buy HoTT with one buyer");
     type OneBuyerBooksellerChoreography = BooksellerChoreography<OneBuyerDecider>;

--- a/chorus_lib/examples/hello.rs
+++ b/chorus_lib/examples/hello.rs
@@ -2,7 +2,7 @@ extern crate chorus_lib;
 
 use std::thread;
 
-use chorus_lib::core::{ChoreoOp, Choreography, ChoreographyLocation, Projector};
+use chorus_lib::core::{ChoreoOp, Choreography, ChoreographyLocation, ProjectorForAL};
 use chorus_lib::hlist;
 use chorus_lib::transport::local::LocalTransport;
 
@@ -41,18 +41,21 @@ fn main() {
     let mut handles: Vec<thread::JoinHandle<()>> = Vec::new();
     // Create a local transport
     let transport = LocalTransport::from(&[Alice::name(), Bob::name()]);
+    // Crate available locations for Projector
+    type AL = hlist!(Alice, Bob);
+
     // Run the choreography in two threads
     {
         let transport = transport.clone();
         handles.push(thread::spawn(move || {
-            let p = Projector::new(Alice, transport);
+            let p = ProjectorForAL::<AL>::new(Alice, transport);
             p.epp_and_run(HelloWorldChoreography);
         }));
     }
     {
         let transport = transport.clone();
         handles.push(thread::spawn(move || {
-            let p = Projector::new(Bob, transport);
+            let p = ProjectorForAL::<AL>::new(Bob, transport);
             p.epp_and_run(HelloWorldChoreography);
         }));
     }

--- a/chorus_lib/examples/hello.rs
+++ b/chorus_lib/examples/hello.rs
@@ -2,8 +2,8 @@ extern crate chorus_lib;
 
 use std::thread;
 
-use chorus_lib::core::{ChoreoOp, Choreography, ChoreographyLocation, ProjectorForAL};
-use chorus_lib::hlist;
+use chorus_lib::core::{ChoreoOp, Choreography, ChoreographyLocation, Projector};
+use chorus_lib::{hlist, projector};
 use chorus_lib::transport::local::LocalTransport;
 
 // --- Define two locations (Alice and Bob) ---
@@ -48,14 +48,14 @@ fn main() {
     {
         let transport = transport.clone();
         handles.push(thread::spawn(move || {
-            let p = ProjectorForAL::<AL>::new(Alice, transport);
+            let p = projector!(AL, Alice, transport);
             p.epp_and_run(HelloWorldChoreography);
         }));
     }
     {
         let transport = transport.clone();
         handles.push(thread::spawn(move || {
-            let p = ProjectorForAL::<AL>::new(Bob, transport);
+            let p = projector!(AL, Bob, transport);
             p.epp_and_run(HelloWorldChoreography);
         }));
     }

--- a/chorus_lib/examples/hello.rs
+++ b/chorus_lib/examples/hello.rs
@@ -3,8 +3,8 @@ extern crate chorus_lib;
 use std::thread;
 
 use chorus_lib::core::{ChoreoOp, Choreography, ChoreographyLocation, Projector};
-use chorus_lib::{hlist, projector};
 use chorus_lib::transport::local::LocalTransport;
+use chorus_lib::{hlist, projector};
 
 // --- Define two locations (Alice and Bob) ---
 

--- a/chorus_lib/examples/hello.rs
+++ b/chorus_lib/examples/hello.rs
@@ -2,9 +2,9 @@ extern crate chorus_lib;
 
 use std::thread;
 
-use chorus_lib::core::{ChoreoOp, Choreography, ChoreographyLocation, Projector};
+use chorus_lib::core::{ChoreoOp, Choreography, ChoreographyLocation};
 use chorus_lib::transport::local::LocalTransport;
-use chorus_lib::{hlist, projector};
+use chorus_lib::{projector, LocationSet};
 
 // --- Define two locations (Alice and Bob) ---
 
@@ -19,7 +19,7 @@ struct HelloWorldChoreography;
 
 // Implement the `Choreography` trait for `HelloWorldChoreography`
 impl Choreography for HelloWorldChoreography {
-    type L = hlist!(Alice, Bob);
+    type L = LocationSet!(Alice, Bob);
     fn run(self, op: &impl ChoreoOp<Self::L>) {
         // Create a located value at Alice
         let msg_at_alice = op.locally(Alice, |_| {
@@ -41,21 +41,19 @@ fn main() {
     let mut handles: Vec<thread::JoinHandle<()>> = Vec::new();
     // Create a local transport
     let transport = LocalTransport::from(&[Alice::name(), Bob::name()]);
-    // Crate available locations for Projector
-    type AL = hlist!(Alice, Bob);
 
     // Run the choreography in two threads
     {
         let transport = transport.clone();
         handles.push(thread::spawn(move || {
-            let p = projector!(AL, Alice, transport);
+            let p = projector!(LocationSet!(Alice, Bob), Alice, transport);
             p.epp_and_run(HelloWorldChoreography);
         }));
     }
     {
         let transport = transport.clone();
         handles.push(thread::spawn(move || {
-            let p = projector!(AL, Bob, transport);
+            let p = projector!(LocationSet!(Alice, Bob), Bob, transport);
             p.epp_and_run(HelloWorldChoreography);
         }));
     }

--- a/chorus_lib/examples/input-output.rs
+++ b/chorus_lib/examples/input-output.rs
@@ -1,7 +1,7 @@
 extern crate chorus_lib;
 use chorus_lib::{
     core::{ChoreoOp, Choreography, ChoreographyLocation, Located},
-    hlist,
+    LocationSet,
 };
 #[derive(ChoreographyLocation)]
 struct Alice;
@@ -15,7 +15,7 @@ struct DemoChoreography {
 }
 
 impl Choreography for DemoChoreography {
-    type L = hlist!(Alice);
+    type L = LocationSet!(Alice);
     fn run(self, op: &impl ChoreoOp<Self::L>) {
         op.locally(Alice, |un| {
             let s = un.unwrap(&self.input);

--- a/chorus_lib/examples/loc-poly.rs
+++ b/chorus_lib/examples/loc-poly.rs
@@ -3,9 +3,9 @@ use std::fmt::Debug;
 use std::thread;
 
 use chorus_lib::core::{
-    ChoreoOp, Choreography, ChoreographyLocation, Located, Portable, ProjectorForAL,
+    ChoreoOp, Choreography, ChoreographyLocation, Located, Portable, Projector,
 };
-use chorus_lib::hlist;
+use chorus_lib::{hlist, projector};
 use chorus_lib::transport::local::LocalTransport;
 
 #[derive(ChoreographyLocation)]
@@ -66,7 +66,7 @@ fn main() {
     {
         let transport = transport.clone();
         handles.push(thread::spawn(|| {
-            let p = ProjectorForAL::<AL>::new(Alice, transport);
+            let p = projector!(AL, Alice, transport);
             let v = p.epp_and_run(MainChoreography);
             assert_eq!(p.unwrap(v), 110);
         }));
@@ -74,7 +74,7 @@ fn main() {
     {
         let transport = transport.clone();
         handles.push(thread::spawn(|| {
-            let p = ProjectorForAL::<AL>::new(Bob, transport);
+            let p = projector!(AL, Bob, transport);
             p.epp_and_run(MainChoreography);
         }));
     }

--- a/chorus_lib/examples/loc-poly.rs
+++ b/chorus_lib/examples/loc-poly.rs
@@ -3,7 +3,7 @@ use std::fmt::Debug;
 use std::thread;
 
 use chorus_lib::core::{
-    ChoreoOp, Choreography, ChoreographyLocation, Located, Portable, Projector,
+    ChoreoOp, Choreography, ChoreographyLocation, Located, Portable, ProjectorForAL,
 };
 use chorus_lib::hlist;
 use chorus_lib::transport::local::LocalTransport;
@@ -59,11 +59,14 @@ impl Choreography<Located<i32, Alice>> for MainChoreography {
 fn main() {
     let transport = LocalTransport::from(&[Alice::name(), Bob::name(), Carol::name()]);
 
+    // Crate available locations for Projector
+    type AL = hlist!(Alice, Bob);
+
     let mut handles = vec![];
     {
         let transport = transport.clone();
         handles.push(thread::spawn(|| {
-            let p = Projector::new(Alice, transport);
+            let p = ProjectorForAL::<AL>::new(Alice, transport);
             let v = p.epp_and_run(MainChoreography);
             assert_eq!(p.unwrap(v), 110);
         }));
@@ -71,7 +74,7 @@ fn main() {
     {
         let transport = transport.clone();
         handles.push(thread::spawn(|| {
-            let p = Projector::new(Bob, transport);
+            let p = ProjectorForAL::<AL>::new(Bob, transport);
             p.epp_and_run(MainChoreography);
         }));
     }

--- a/chorus_lib/examples/loc-poly.rs
+++ b/chorus_lib/examples/loc-poly.rs
@@ -5,8 +5,8 @@ use std::thread;
 use chorus_lib::core::{
     ChoreoOp, Choreography, ChoreographyLocation, Located, Portable, Projector,
 };
-use chorus_lib::{hlist, projector};
 use chorus_lib::transport::local::LocalTransport;
+use chorus_lib::{hlist, projector};
 
 #[derive(ChoreographyLocation)]
 struct Alice;

--- a/chorus_lib/examples/runner.rs
+++ b/chorus_lib/examples/runner.rs
@@ -1,7 +1,7 @@
 extern crate chorus_lib;
 use chorus_lib::{
     core::{ChoreoOp, Choreography, ChoreographyLocation, Located, Runner, Superposition},
-    hlist,
+    LocationSet,
 };
 
 #[derive(ChoreographyLocation)]
@@ -26,7 +26,7 @@ struct BobCarolChoreography {
 }
 
 impl Choreography<BobCarolResult> for BobCarolChoreography {
-    type L = hlist!(Bob, Carol);
+    type L = LocationSet!(Bob, Carol);
     fn run(self, op: &impl ChoreoOp<Self::L>) -> BobCarolResult {
         let is_even_at_bob: Located<bool, Bob> = op.locally(Bob, |un| {
             let x = un.unwrap(&self.x_at_bob);
@@ -50,7 +50,7 @@ impl Choreography<BobCarolResult> for BobCarolChoreography {
 struct MainChoreography;
 
 impl Choreography for MainChoreography {
-    type L = hlist!(Alice, Bob, Carol);
+    type L = LocationSet!(Alice, Bob, Carol);
     fn run(self, op: &impl ChoreoOp<Self::L>) {
         let x_at_alice = op.locally(Alice, |_| get_random_number());
         let x_at_bob = op.comm(Alice, Bob, &x_at_alice);

--- a/chorus_lib/examples/tic-tac-toe.rs
+++ b/chorus_lib/examples/tic-tac-toe.rs
@@ -3,7 +3,8 @@ extern crate chorus_lib;
 
 use chorus_lib::{
     core::{
-        ChoreoOp, Choreography, ChoreographyLocation, Deserialize, Located, ProjectorForAL, Serialize,
+        ChoreoOp, Choreography, ChoreographyLocation, Deserialize, Located, ProjectorForAL,
+        Serialize,
     },
     hlist,
     transport::http::HttpTransport,

--- a/chorus_lib/examples/tic-tac-toe.rs
+++ b/chorus_lib/examples/tic-tac-toe.rs
@@ -3,10 +3,10 @@ extern crate chorus_lib;
 
 use chorus_lib::{
     core::{
-        ChoreoOp, Choreography, ChoreographyLocation, Deserialize, Located, ProjectorForAL,
+        ChoreoOp, Choreography, ChoreographyLocation, Deserialize, Located, Projector,
         Serialize,
     },
-    hlist,
+    hlist, projector,
     transport::http::HttpTransport,
 };
 use clap::Parser;
@@ -304,7 +304,7 @@ fn main() {
                 (args.opponent_hostname.as_str(), args.opponent_port),
             );
             let transport = HttpTransport::new(PlayerX::name(), &config);
-            let projector = ProjectorForAL::<AL>::new(PlayerX, transport);
+            let projector = projector!(AL, PlayerX, transport);
             projector.epp_and_run(TicTacToeChoreography {
                 brain_for_x: projector.local(brain),
                 brain_for_o: projector.remote(PlayerO),
@@ -318,7 +318,7 @@ fn main() {
                 (args.opponent_hostname.as_str(), args.opponent_port),
             );
             let transport = HttpTransport::new(PlayerO::name(), &config);
-            let projector = ProjectorForAL::<AL>::new(PlayerO, transport);
+            let projector = projector!(AL, PlayerO, transport);
             projector.epp_and_run(TicTacToeChoreography {
                 brain_for_x: projector.remote(PlayerX),
                 brain_for_o: projector.local(brain),

--- a/chorus_lib/examples/tic-tac-toe.rs
+++ b/chorus_lib/examples/tic-tac-toe.rs
@@ -2,11 +2,10 @@
 extern crate chorus_lib;
 
 use chorus_lib::{
-    core::{
-        ChoreoOp, Choreography, ChoreographyLocation, Deserialize, Located, Projector, Serialize,
-    },
-    hlist, projector,
+    core::{ChoreoOp, Choreography, ChoreographyLocation, Deserialize, Located, Serialize},
+    projector,
     transport::http::HttpTransport,
+    LocationSet,
 };
 use clap::Parser;
 use std::{collections::HashMap, io::Write};
@@ -228,7 +227,7 @@ struct TicTacToeChoreography {
 }
 
 impl Choreography for TicTacToeChoreography {
-    type L = hlist!(PlayerX, PlayerO);
+    type L = LocationSet!(PlayerX, PlayerO);
     fn run(self, op: &impl ChoreoOp<Self::L>) -> () {
         let mut board = Board::new();
         loop {
@@ -291,9 +290,6 @@ fn main() {
         Box::new(UserBrain::new(args.player))
     };
 
-    // Crate available locations for Projector
-    type AL = hlist!(PlayerX, PlayerO);
-
     match args.player {
         'X' => {
             let mut config = HashMap::new();
@@ -303,7 +299,7 @@ fn main() {
                 (args.opponent_hostname.as_str(), args.opponent_port),
             );
             let transport = HttpTransport::new(PlayerX::name(), &config);
-            let projector = projector!(AL, PlayerX, transport);
+            let projector = projector!(LocationSet!(PlayerX, PlayerO), PlayerX, transport);
             projector.epp_and_run(TicTacToeChoreography {
                 brain_for_x: projector.local(brain),
                 brain_for_o: projector.remote(PlayerO),
@@ -317,7 +313,7 @@ fn main() {
                 (args.opponent_hostname.as_str(), args.opponent_port),
             );
             let transport = HttpTransport::new(PlayerO::name(), &config);
-            let projector = projector!(AL, PlayerO, transport);
+            let projector = projector!(LocationSet!(PlayerX, PlayerO), PlayerO, transport);
             projector.epp_and_run(TicTacToeChoreography {
                 brain_for_x: projector.remote(PlayerX),
                 brain_for_o: projector.local(brain),

--- a/chorus_lib/examples/tic-tac-toe.rs
+++ b/chorus_lib/examples/tic-tac-toe.rs
@@ -3,8 +3,7 @@ extern crate chorus_lib;
 
 use chorus_lib::{
     core::{
-        ChoreoOp, Choreography, ChoreographyLocation, Deserialize, Located, Projector,
-        Serialize,
+        ChoreoOp, Choreography, ChoreographyLocation, Deserialize, Located, Projector, Serialize,
     },
     hlist, projector,
     transport::http::HttpTransport,

--- a/chorus_lib/examples/tic-tac-toe.rs
+++ b/chorus_lib/examples/tic-tac-toe.rs
@@ -3,7 +3,7 @@ extern crate chorus_lib;
 
 use chorus_lib::{
     core::{
-        ChoreoOp, Choreography, ChoreographyLocation, Deserialize, Located, Projector, Serialize,
+        ChoreoOp, Choreography, ChoreographyLocation, Deserialize, Located, ProjectorForAL, Serialize,
     },
     hlist,
     transport::http::HttpTransport,
@@ -290,6 +290,10 @@ fn main() {
     } else {
         Box::new(UserBrain::new(args.player))
     };
+
+    // Crate available locations for Projector
+    type AL = hlist!(PlayerX, PlayerO);
+
     match args.player {
         'X' => {
             let mut config = HashMap::new();
@@ -299,7 +303,7 @@ fn main() {
                 (args.opponent_hostname.as_str(), args.opponent_port),
             );
             let transport = HttpTransport::new(PlayerX::name(), &config);
-            let projector = Projector::new(PlayerX, transport);
+            let projector = ProjectorForAL::<AL>::new(PlayerX, transport);
             projector.epp_and_run(TicTacToeChoreography {
                 brain_for_x: projector.local(brain),
                 brain_for_o: projector.remote(PlayerO),
@@ -313,7 +317,7 @@ fn main() {
                 (args.opponent_hostname.as_str(), args.opponent_port),
             );
             let transport = HttpTransport::new(PlayerO::name(), &config);
-            let projector = Projector::new(PlayerO, transport);
+            let projector = ProjectorForAL::<AL>::new(PlayerO, transport);
             projector.epp_and_run(TicTacToeChoreography {
                 brain_for_x: projector.remote(PlayerX),
                 brain_for_o: projector.local(brain),

--- a/chorus_lib/src/core.rs
+++ b/chorus_lib/src/core.rs
@@ -168,22 +168,6 @@ where
 {
 }
 
-/// Equal
-pub trait Equal<L: HList, Index> {}
-
-// Base case: HNil is equal to HNil
-impl Equal<HNil, Here> for HNil {}
-
-// Recursive case: Head::Tail is equal to L if
-// 1. Head is a member of L
-// 2. Tail is equal to the remainder of L
-impl<L: HList, Head, Tail, Index1, Index2> Equal<L, HCons<Index1, Index2>> for HCons<Head, Tail>
-where
-    Head: Member<L, Index1>,
-    Tail: Equal<Head::Remainder, Index2>,
-{
-}
-
 /// Provides a method to work with located values at the current location
 pub struct Unwrapper<L1: ChoreographyLocation> {
     phantom: PhantomData<L1>,
@@ -363,7 +347,7 @@ where
         choreo: C,
     ) -> V
     where
-        L: Equal<AL, IndexSet>,
+        L: Subset<AL, IndexSet>,
     {
         struct EppOp<'a, L: HList, L1: ChoreographyLocation, B: Transport> {
             target: PhantomData<L1>,

--- a/chorus_lib/src/core.rs
+++ b/chorus_lib/src/core.rs
@@ -343,8 +343,6 @@ where
     /// Constructs a `Located` struct *NOT* located at the projection target.
     ///
     /// Use this method to run a choreography that takes a located value as an input.
-    ///
-    /// Note that the method panics at runtime if the projection target and the location of the value are the same.
     pub fn remote<V, L2: ChoreographyLocation, Index2>(&self, _l2: L2) -> Located<V, L2>
     where
         L2: Member<<L1 as Member<AL, Index>>::Remainder, Index2>,

--- a/chorus_lib/src/core.rs
+++ b/chorus_lib/src/core.rs
@@ -169,20 +169,20 @@ where
 }
 
 /// Equal
- pub trait Equal<L: HList, Index> {}
+pub trait Equal<L: HList, Index> {}
 
- // Base case: HNil is equal to HNil
- impl Equal<HNil, Here> for HNil {}
+// Base case: HNil is equal to HNil
+impl Equal<HNil, Here> for HNil {}
 
- // Recursive case: Head::Tail is equal to L if
- // 1. Head is a member of L
- // 2. Tail is equal to the remainder of L
- impl<L: HList, Head, Tail, Index1, Index2> Equal<L, HCons<Index1, Index2>> for HCons<Head, Tail>
- where
-     Head: Member<L, Index1>,
-     Tail: Equal<Head::Remainder, Index2>,
- {
- }
+// Recursive case: Head::Tail is equal to L if
+// 1. Head is a member of L
+// 2. Tail is equal to the remainder of L
+impl<L: HList, Head, Tail, Index1, Index2> Equal<L, HCons<Index1, Index2>> for HCons<Head, Tail>
+where
+    Head: Member<L, Index1>,
+    Tail: Equal<Head::Remainder, Index2>,
+{
+}
 
 /// Provides a method to work with located values at the current location
 pub struct Unwrapper<L1: ChoreographyLocation> {
@@ -287,8 +287,10 @@ pub trait Transport {
 }
 
 /// Provides a method to perform end-point projection.
-pub struct Projector<AL: HList, L1: ChoreographyLocation, T: Transport, Index> where 
-    L1: Member<AL, Index>{
+pub struct Projector<AL: HList, L1: ChoreographyLocation, T: Transport, Index>
+where
+    L1: Member<AL, Index>,
+{
     target: PhantomData<L1>,
     transport: T,
     available_locations: PhantomData<AL>,
@@ -314,15 +316,15 @@ impl<AL: HList> ProjectorForAL<AL> {
     }
 }
 
-impl<AL: HList, L1: ChoreographyLocation, B: Transport, Index> Projector<AL, L1, B, Index> 
-    where L1: Member<AL, Index> 
+impl<AL: HList, L1: ChoreographyLocation, B: Transport, Index> Projector<AL, L1, B, Index>
+where
+    L1: Member<AL, Index>,
 {
     /// Constructs a `Projector` struct.
     ///
     /// - `target` is the projection target of the choreography.
     /// - `transport` is an implementation of `Transport`.
-    pub fn new(_target: L1, transport: B) -> Self
-    {
+    pub fn new(_target: L1, transport: B) -> Self {
         Projector {
             target: PhantomData,
             transport,
@@ -334,8 +336,7 @@ impl<AL: HList, L1: ChoreographyLocation, B: Transport, Index> Projector<AL, L1,
     /// Constructs a `Located` struct located at the projection target using the actual value.
     ///
     /// Use this method to run a choreography that takes a located value as an input.
-    pub fn local<V>(&self, value: V) -> Located<V, L1>
-    {
+    pub fn local<V>(&self, value: V) -> Located<V, L1> {
         Located::local(value)
     }
 
@@ -359,7 +360,10 @@ impl<AL: HList, L1: ChoreographyLocation, B: Transport, Index> Projector<AL, L1,
     }
 
     /// Performs end-point projection and runs a choreography.
-    pub fn epp_and_run<'a, V, L: HList, C: Choreography<V, L = L>, IndexSet>(&'a self, choreo: C) -> V
+    pub fn epp_and_run<'a, V, L: HList, C: Choreography<V, L = L>, IndexSet>(
+        &'a self,
+        choreo: C,
+    ) -> V
     where
         L: Equal<AL, IndexSet>,
     {

--- a/chorus_lib/src/core.rs
+++ b/chorus_lib/src/core.rs
@@ -281,23 +281,12 @@ where
     index: PhantomData<Index>,
 }
 
-/// Provides a wrapper struct for users so that they can only specify AL; since it can't be inferred.
-pub struct ProjectorForAL<AL: HList>(PhantomData<AL>);
-
-impl<AL: HList> ProjectorForAL<AL> {
-    /// Constructs a `Projector` struct.
-    ///
-    /// - `target` is the projection target of the choreography.
-    /// - `transport` is an implementation of `Transport`.
-    pub fn new<L1: ChoreographyLocation, B: Transport, Index>(
-        target: L1,
-        transport: B,
-    ) -> Projector<AL, L1, B, Index>
-    where
-        L1: Member<AL, Index>,
-    {
-        Projector::new(target, transport)
-    }
+/// Macro to make Projector
+#[macro_export]
+macro_rules! projector {
+    ($al_type:ty, $target:expr, $transport:expr) => {
+        Projector::<$al_type, _, _, _>::new($target, $transport)
+    };
 }
 
 impl<AL: HList, L1: ChoreographyLocation, B: Transport, Index> Projector<AL, L1, B, Index>


### PR DESCRIPTION
This is based on our discussion to have a set of available locations for the Projector struct so that we can do type-checking on the arguments passed to each Projector's methods. Specifically, this helps with the `remote` method and we don't need this check anymore:
```rust
if L1::name() == L2::name() {
    panic!("Cannot create a remote value at the same location");
}
```
Now, we instead have a compile-time check that makes sure L1 and L2 are different.