### PR TITLE
Allow the Transport to have a different kind of information for the target ChoreographyLocation

### DIFF
--- a/chorus_book/src/guide-input-and-output.md
+++ b/chorus_book/src/guide-input-and-output.md
@@ -43,7 +43,7 @@ let choreo = DemoChoreography {
     input: "World".to_string(),
 };
 
-let projector = Projector::new(Alice, transport);
+let projector = Projector::new(Alice, alice_transport);
 projector.epp_and_run(choreo);
 ```
 
@@ -93,7 +93,7 @@ To run the sample choreography above at Alice, we use the `local` method to cons
 #         });
 #     }
 # }
-let projector_for_alice = Projector::new(Alice, transport);
+let projector_for_alice = Projector::new(Alice, alice_transport);
 // Because the target of the projector is Alice, the located value is available at Alice.
 let string_at_alice: Located<String, Alice> = projector_for_alice.local("Hello, World!".to_string());
 // Instantiate the choreography with the located value
@@ -120,7 +120,7 @@ For Bob, we use the `remote` method to construct the located value.
 #         });
 #     }
 # }
-let projector_for_bob = Projector::new(Bob, transport);
+let projector_for_bob = Projector::new(Bob, bob_transport);
 // Construct a remote located value at Alice. The actual value is not required.
 let string_at_alice = projector_for_bob.remote(Alice);
 // Instantiate the choreography with the located value
@@ -161,7 +161,7 @@ impl Choreography<String> for DemoChoreography {
 #     }
 # }
 let choreo = DemoChoreography;
-let projector = Projector::new(Alice, transport);
+let projector = Projector::new(Alice, alice_transport);
 let output = projector.epp_and_run(choreo);
 assert_eq!(output, "Hello, World!".to_string());
 ```
@@ -183,7 +183,7 @@ impl Choreography<Located<String, Alice>> for DemoChoreography {
     }
 }
 
-let projector = Projector::new(Alice, transport);
+let projector = Projector::new(Alice, alice_transport);
 let output = projector.epp_and_run(DemoChoreography);
 let string_at_alice = projector.unwrap(output);
 assert_eq!(string_at_alice, "Hello, World!".to_string());

--- a/chorus_book/src/guide-projector.md
+++ b/chorus_book/src/guide-projector.md
@@ -8,17 +8,19 @@ To create a `Projector`, you need to provide the target location and the transpo
 
 ```rust
 # extern crate chorus_lib;
-# use chorus_lib::transport::local::LocalTransport;
+# use std::sync::Arc;
+# use chorus_lib::transport::local::{LocalTransport, LocalTransportChannel};
 # use chorus_lib::core::{ChoreographyLocation, Projector};
 # use chorus_lib::{LocationSet};
-# let transport = LocalTransport::<LocationSet!(Alice, Bob)>::new();
+# let transport_channel = Arc::new(LocalTransportChannel::<LocationSet!(Alice, Bob)>::new());
+# let alice_transport = LocalTransport::new(Alice, Arc::clone(&transport_channel));
 # #[derive(ChoreographyLocation)]
 # struct Alice;
 # #[derive(ChoreographyLocation)]
 # struct Bob;
 #
 
-let projector = Projector::new(Alice, transport);
+let projector = Projector::new(Alice, alice_transport);
 ```
 
 Notice that the `Projector` is parameterized by its target location type. You will need one projector for each location to execute choreography.
@@ -29,10 +31,12 @@ To execute a choreography, you need to call the `epp_and_run` method on the `Pro
 
 ```rust
 # extern crate chorus_lib;
-# use chorus_lib::transport::local::LocalTransport;
+# use std::sync::Arc;
+# use chorus_lib::transport::local::{LocalTransport, LocalTransportChannel};
 # use chorus_lib::core::{ChoreographyLocation, Projector, Choreography, ChoreoOp};
 # use chorus_lib::{LocationSet};
-# let transport = LocalTransport::<LocationSet!(Alice, Bob)>::new();
+# let transport_channel = Arc::new(LocalTransportChannel::<LocationSet!(Alice, Bob)>::new());
+# let alice_transport = LocalTransport::new(Alice, Arc::clone(&transport_channel));
 # #[derive(ChoreographyLocation)]
 # struct Alice;
 # #[derive(ChoreographyLocation)]
@@ -45,7 +49,7 @@ To execute a choreography, you need to call the `epp_and_run` method on the `Pro
 # }
 #
 
-# let projector = Projector::new(Alice, transport);
+# let projector = Projector::new(Alice, alice_transport);
 projector.epp_and_run(HelloWorldChoreography);
 ```
 

--- a/chorus_book/src/guide-transport.md
+++ b/chorus_book/src/guide-transport.md
@@ -8,22 +8,47 @@ ChoRus provides two built-in transports: `local` and `http`.
 
 ### The Local Transport
 
-The `local` transport is used to execute choreographies on the same machine on different threads. This is useful for testing and prototyping.
-
-To use the `local` transport, import the `LocalTransport` struct from the `chorus_lib` crate.
+The `local` transport is used to execute choreographies on the same machine on different threads. This is useful for testing and prototyping. Each `local` transport is defined over `LocalTransportChannel`, which contains the set of `ChoreographyLocation` that the `local` transport operates on. You can build a `LocalTransportChannel` by importing the `LocalTransportChannel` stsruct from the `chorus_lib` crate.
 
 ```rust
 # extern crate chorus_lib;
-use chorus_lib::transport::local::LocalTransport;
+# use std::sync::Arc;
+# use chorus_lib::core::{ChoreographyLocation};
+# use chorus_lib::{LocationSet};
+# #[derive(ChoreographyLocation)]
+# struct Alice;
+# #[derive(ChoreographyLocation)]
+# struct Bob;
+use chorus_lib::transport::local::LocalTransportChannel;
+
+let transport_channel = Arc::new(LocalTransportChannel::<LocationSet!(Alice, Bob)>::new());
 ```
 
-You can construct a `LocalTransport` instance by passing a slice of locations to the `from` method.
-
-Because of the nature of the `Local` transport, you must use the same `LocalTransport` instance for all locations. You can `clone` the `LocalTransport` instance and pass it to the threads.
+To use the `local` transport, first import the `LocalTransport` struct from the `chorus_lib` crate.
 
 ```rust
 # extern crate chorus_lib;
-# use chorus_lib::transport::local::LocalTransport;
+# use std::sync::Arc;
+# use chorus_lib::core::{ChoreographyLocation};
+# use chorus_lib::{LocationSet};
+# #[derive(ChoreographyLocation)]
+# struct Alice;
+# let transport_channel = Arc::new(LocalTransportChannel::<LocationSet!(Alice)>::new());
+use chorus_lib::transport::local::{LocalTransport, LocalTransportChannel};
+
+let alice_transport = LocalTransport::new(Alice, Arc::clone(&transport_channel));
+```
+
+ Then build the transport by using the `LocalTransport::new` associated function, which takes a target location (explained in the [Projector section](./guide-projector.md)) and the `LocalTransportChannel`.
+
+You can construct a `LocalTransport` instance by passing a target location(lained in the [Projector section](./guide-projector.md)) and a `std::sync::Arc` of `LocalTransportChannel` to the `new` method.
+
+Because of the nature of the `Local` transport, you must make a `std::sync::Arc` from the `LocalTransportChannel`, by using the `std::sync::Arc::clone(&local_transport)`.
+
+```rust
+# extern crate chorus_lib;
+# use std::sync::Arc;
+# use chorus_lib::transport::local::{LocalTransport, LocalTransportChannel};
 # use std::thread;
 # use chorus_lib::core::{ChoreographyLocation, ChoreoOp, Choreography, Projector};
 # use chorus_lib::{LocationSet};
@@ -37,13 +62,11 @@ Because of the nature of the `Local` transport, you must use the same `LocalTran
 #     fn run(self, op: &impl ChoreoOp<Self::L>) {
 #     }
 # }
-
-
+let transport_channel = Arc::new(LocalTransportChannel::<LocationSet!(Alice, Bob)>::new());
 let mut handles: Vec<thread::JoinHandle<()>> = Vec::new();
-let transport = LocalTransport::<LocationSet!(Alice, Bob)>::new();
 {
-    // create a clone for Alice
-    let transport = transport.clone();
+    // create a transport for Alice
+    let transport = LocalTransport::new(Alice, Arc::clone(&transport_channel));
     handles.push(thread::spawn(move || {
         let p = Projector::new(Alice, transport);
         p.epp_and_run(HelloWorldChoreography);
@@ -51,7 +74,7 @@ let transport = LocalTransport::<LocationSet!(Alice, Bob)>::new();
 }
 {
     // create another for Bob
-    let transport = transport.clone();
+    let transport = LocalTransport::new(Bob, Arc::clone(&transport_channel));
     handles.push(thread::spawn(move || {
         let p = Projector::new(Bob, transport);
         p.epp_and_run(HelloWorldChoreography);
@@ -63,24 +86,26 @@ let transport = LocalTransport::<LocationSet!(Alice, Bob)>::new();
 
 The `http` transport is used to execute choreographies on different machines. This is useful for executing choreographies in a distributed system.
 
-To use the `http` transport, import the `HttpTransport` struct and the `http_config` macro from the `chorus_lib` crate.
+To use the `http` transport, import the `HttpTransport` struct and the `transport_config` macro from the `chorus_lib` crate.
 
 ```rust
 # extern crate chorus_lib;
 use chorus_lib::transport::http::HttpTransport;
-use chorus_lib::http_config;
+use chorus_lib::transport_config;
 ```
 
-The `new` constructor takes the name of the projection target and "configuration" of type `HttpConfig`. To build the `HttpConfig`, you should use the macro `http_config` and give it a comma separatedlist of key: values where each key is a `ChoreographyLocation` and each value is a tuple of (host_name, port). You can think of configuration as a map from locations to the hostname and port of the location.
+The new constructor takes a "configuration" of type TransportConfig. To build the TransportConfig, you should use the macro transport_config and give it a key => value, followed by a comma (if you have more than one key/value), and a comma-separated list of key: values where the key => value is the target ChoreographyLocation and the value is the required information for the target, and each following key: value is a ChoreographyLocation and the required information for it (`(host_name, port)` in this case). For HttpTransport You can think of TransportConfig as a map from locations to the hostname and port of the location. But for a generic Transport, it can contain any kind of information.
 
 ```rust
 {{#include ./header.txt}}
 # use chorus_lib::transport::http::{HttpTransport};
-# use chorus_lib::http_config;
-# use std::collections::HashMap;
+# use chorus_lib::transport_config;
+let config = transport_config!(
+                Alice => ("0.0.0.0".to_string(), 9010),
+                Bob: ("localhost".to_string(), 9011)
+            );
 
-let config = http_config!(Alice: ("localhost", 8080), Bob: ("localhost", 8081));
-let transport = HttpTransport::new(Alice, &config);
+let transport = HttpTransport::new(&config);
 ```
 
 In the above example, the transport will start the HTTP server on port 8080 on localhost. If Alice needs to send a message to Bob, it will use `http://localhost:8081` as the destination.
@@ -96,7 +121,8 @@ Note that when calling `epp_and_run` on a `Projector`, you will get a compile er
 
 ```rust, compile_fail
 # extern crate chorus_lib;
-# use chorus_lib::transport::local::LocalTransport;
+# use std::sync::Arc;
+# use chorus_lib::transport::local::{LocalTransport, LocalTransportChannel};
 # use chorus_lib::core::{ChoreographyLocation, Projector, Choreography, ChoreoOp};
 # use chorus_lib::{LocationSet};
 
@@ -111,7 +137,8 @@ impl Choreography for HelloWorldChoreography {
      }
 }
 
-let transport = LocalTransport::<LocationSet!(Alice)>::new();
+let transport_channel = Arc::new(LocalTransportChannel::<LocationSet!(Alice)>::new());
+let transport = LocalTransport::new(Alice, Arc::clone(&transport_channel));
 let projector = Projector::new(Alice, transport);
 projector.epp_and_run(HelloWorldChoreography);
 ```

--- a/chorus_book/src/header.txt
+++ b/chorus_book/src/header.txt
@@ -1,6 +1,7 @@
 # extern crate chorus_lib;
+# use std::sync::Arc;
 # use chorus_lib::core::{ChoreoOp, Choreography, ChoreographyLocation, Projector, Located, Superposition, Runner};
-# use chorus_lib::transport::local::LocalTransport;
+# use chorus_lib::transport::local::{LocalTransport, LocalTransportChannel};
 # use chorus_lib::{LocationSet};
 # #[derive(ChoreographyLocation)]
 # struct Alice;
@@ -8,4 +9,7 @@
 # struct Bob;
 # #[derive(ChoreographyLocation)]
 # struct Carol;
-# let transport = LocalTransport::<LocationSet!(Alice, Bob, Carol)>::new();
+# let transport_channel = Arc::new(LocalTransportChannel::<LocationSet!(Alice, Bob, Carol)>::new());
+# let alice_transport = LocalTransport::new(Alice, Arc::clone(&transport_channel));
+# let bob_transport = LocalTransport::new(Bob, Arc::clone(&transport_channel));
+# let carol_transport = LocalTransport::new(Carol, Arc::clone(&transport_channel));

--- a/chorus_lib/examples/bookseller.rs
+++ b/chorus_lib/examples/bookseller.rs
@@ -1,13 +1,13 @@
 extern crate chorus_lib;
 
 use std::io;
+use std::sync::Arc;
 use std::thread;
 
 use chrono::NaiveDate;
 
 use chorus_lib::core::{ChoreoOp, Choreography, ChoreographyLocation, Projector};
-use chorus_lib::transport::local::LocalTransport;
-use chorus_lib::transport_config;
+use chorus_lib::transport::local::{LocalTransport, LocalTransportChannel};
 use chorus_lib::LocationSet;
 
 fn get_book(title: &str) -> Option<(i32, NaiveDate)> {
@@ -74,24 +74,10 @@ impl Choreography for BooksellerChoreography {
 }
 
 fn main() {
-    // let config = transport_config!(Seller: (), Buyer: ());
+    let transport_channel = Arc::new(LocalTransportChannel::<LocationSet!(Seller, Buyer)>::new());
 
-    let transport_channel = LocalTransport::<LocationSet!(Seller, Buyer)>::transport_channel();
-
-    let config_seller = transport_config!(
-            Seller,
-            Buyer: (),
-            Seller: (),
-    );
-
-    let config_buyer = transport_config!(
-            Buyer,
-            Buyer: (),
-            Seller: (),
-    );
-
-    let transport_seller = LocalTransport::new(&config_seller, transport_channel.clone());
-    let transport_buyer = LocalTransport::new(&config_buyer, transport_channel.clone());
+    let transport_seller = LocalTransport::new(Seller, Arc::clone(&transport_channel));
+    let transport_buyer = LocalTransport::new(Buyer, Arc::clone(&transport_channel));
 
     let seller_projector = Projector::new(Seller, transport_seller);
     let buyer_projector = Projector::new(Buyer, transport_buyer);

--- a/chorus_lib/examples/bookseller.rs
+++ b/chorus_lib/examples/bookseller.rs
@@ -74,11 +74,27 @@ impl Choreography for BooksellerChoreography {
 }
 
 fn main() {
-    let config = transport_config!(Seller: (), Buyer: ());
+    // let config = transport_config!(Seller: (), Buyer: ());
 
-    let transport = LocalTransport::new(&config);
-    let seller_projector = Projector::new(Seller, transport.clone());
-    let buyer_projector = Projector::new(Buyer, transport.clone());
+    let transport_channel = LocalTransport::<LocationSet!(Seller, Buyer)>::transport_channel();
+
+    let config_seller = transport_config!(
+            Seller,
+            Buyer: (),
+            Seller: (),
+    );
+
+    let config_buyer = transport_config!(
+            Buyer,
+            Buyer: (),
+            Seller: (),
+    );
+
+    let transport_seller = LocalTransport::new(&config_seller, transport_channel.clone());
+    let transport_buyer = LocalTransport::new(&config_buyer, transport_channel.clone());
+
+    let seller_projector = Projector::new(Seller, transport_seller);
+    let buyer_projector = Projector::new(Buyer, transport_buyer);
 
     let mut handles: Vec<thread::JoinHandle<()>> = Vec::new();
     handles.push(thread::spawn(move || {

--- a/chorus_lib/examples/bookseller.rs
+++ b/chorus_lib/examples/bookseller.rs
@@ -7,6 +7,7 @@ use chrono::NaiveDate;
 
 use chorus_lib::core::{ChoreoOp, Choreography, ChoreographyLocation, Projector};
 use chorus_lib::transport::local::LocalTransport;
+use chorus_lib::transport_config;
 use chorus_lib::LocationSet;
 
 fn get_book(title: &str) -> Option<(i32, NaiveDate)> {
@@ -73,7 +74,9 @@ impl Choreography for BooksellerChoreography {
 }
 
 fn main() {
-    let transport = LocalTransport::<LocationSet!(Seller, Buyer)>::new();
+    let config = transport_config!(Seller: (), Buyer: ());
+
+    let transport = LocalTransport::new(&config);
     let seller_projector = Projector::new(Seller, transport.clone());
     let buyer_projector = Projector::new(Buyer, transport.clone());
 

--- a/chorus_lib/examples/bookseller2.rs
+++ b/chorus_lib/examples/bookseller2.rs
@@ -1,7 +1,7 @@
 extern crate chorus_lib;
 
 use std::thread;
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::HashMap};
 
 use chorus_lib::transport_config;
 use chorus_lib::LocationSet;
@@ -143,17 +143,25 @@ fn main() {
         i
     };
 
-    let config = transport_config!(Seller: (), Buyer1: (), Buyer2: ());
-    let transport = LocalTransport::new(&config);
-    let seller_projector = Arc::new(Projector::new(Seller, transport.clone()));
-    let buyer1_projector = Arc::new(Projector::new(Buyer1, transport.clone()));
-    let buyer2_projector = Arc::new(Projector::new(Buyer2, transport.clone()));
+    let transport_channel =
+        LocalTransport::<LocationSet!(Seller, Buyer1, Buyer2)>::transport_channel();
 
     println!("Tries to buy HoTT with one buyer");
     type OneBuyerBooksellerChoreography = BooksellerChoreography<OneBuyerDecider>;
     let mut handles = Vec::new();
     {
-        let seller_projector = seller_projector.clone();
+        let config = transport_config!(
+            Seller,
+            Seller: (),
+            Buyer1: (),
+            Buyer2: (),
+        );
+
+        let transport_channel = transport_channel.clone();
+        let transport = LocalTransport::new(&config, transport_channel);
+
+        let seller_projector = Projector::new(Seller, transport);
+
         let inventory = inventory.clone();
         handles.push(thread::spawn(move || {
             seller_projector.epp_and_run(OneBuyerBooksellerChoreography {
@@ -164,7 +172,18 @@ fn main() {
         }));
     }
     {
-        let buyer1_projector = buyer1_projector.clone();
+        let config = transport_config!(
+            Buyer1,
+            Seller: (),
+            Buyer1: (),
+            Buyer2: (),
+        );
+
+        let transport_channel = transport_channel.clone();
+        let transport = LocalTransport::new(&config, transport_channel);
+
+        let buyer1_projector = Projector::new(Buyer1, transport);
+
         handles.push(thread::spawn(move || {
             let result = buyer1_projector.epp_and_run(OneBuyerBooksellerChoreography {
                 _marker: std::marker::PhantomData,
@@ -178,7 +197,18 @@ fn main() {
         }));
     }
     {
-        let buyer2_projector = buyer2_projector.clone();
+        let config = transport_config!(
+            Buyer2,
+            Seller: (),
+            Buyer1: (),
+            Buyer2: (),
+        );
+
+        let transport_channel = transport_channel.clone();
+        let transport = LocalTransport::new(&config, transport_channel);
+
+        let buyer2_projector = Projector::new(Buyer2, transport);
+
         handles.push(thread::spawn(move || {
             buyer2_projector.epp_and_run(OneBuyerBooksellerChoreography {
                 _marker: std::marker::PhantomData,
@@ -195,7 +225,18 @@ fn main() {
     type TwoBuyerBooksellerChoreography = BooksellerChoreography<TwoBuyerDecider>;
     let mut handles = Vec::new();
     {
-        let seller_projector = seller_projector.clone();
+        let config = transport_config!(
+            Seller,
+            Seller: (),
+            Buyer1: (),
+            Buyer2: (),
+        );
+
+        let transport_channel = transport_channel.clone();
+        let transport = LocalTransport::new(&config, transport_channel);
+
+        let seller_projector = Projector::new(Seller, transport);
+
         let inventory = inventory.clone();
         handles.push(thread::spawn(move || {
             seller_projector.epp_and_run(TwoBuyerBooksellerChoreography {
@@ -206,7 +247,18 @@ fn main() {
         }));
     }
     {
-        let buyer1_projector = buyer1_projector.clone();
+        let config = transport_config!(
+            Buyer1,
+            Seller: (),
+            Buyer1: (),
+            Buyer2: (),
+        );
+
+        let transport_channel = transport_channel.clone();
+        let transport = LocalTransport::new(&config, transport_channel);
+
+        let buyer1_projector = Projector::new(Buyer1, transport);
+
         handles.push(thread::spawn(move || {
             let result = buyer1_projector.epp_and_run(TwoBuyerBooksellerChoreography {
                 _marker: std::marker::PhantomData,
@@ -220,7 +272,18 @@ fn main() {
         }));
     }
     {
-        let buyer2_projector = buyer2_projector.clone();
+        let config = transport_config!(
+            Buyer2,
+            Seller: (),
+            Buyer1: (),
+            Buyer2: (),
+        );
+
+        let transport_channel = transport_channel.clone();
+        let transport = LocalTransport::new(&config, transport_channel);
+
+        let buyer2_projector = Projector::new(Buyer2, transport);
+
         handles.push(thread::spawn(move || {
             buyer2_projector.epp_and_run(TwoBuyerBooksellerChoreography {
                 _marker: std::marker::PhantomData,

--- a/chorus_lib/examples/bookseller2.rs
+++ b/chorus_lib/examples/bookseller2.rs
@@ -1,7 +1,7 @@
 extern crate chorus_lib;
 
+use std::collections::HashMap;
 use std::thread;
-use std::{collections::HashMap};
 
 use chorus_lib::transport_config;
 use chorus_lib::LocationSet;

--- a/chorus_lib/examples/bookseller2.rs
+++ b/chorus_lib/examples/bookseller2.rs
@@ -3,12 +3,12 @@ extern crate chorus_lib;
 use std::thread;
 use std::{collections::HashMap, sync::Arc};
 
+use chorus_lib::transport_config;
 use chorus_lib::LocationSet;
 use chorus_lib::{
     core::{ChoreoOp, Choreography, ChoreographyLocation, Located, Projector},
     transport::local::LocalTransport,
 };
-use chorus_lib::transport_config;
 use chrono::NaiveDate;
 
 #[derive(ChoreographyLocation)]

--- a/chorus_lib/examples/bookseller2.rs
+++ b/chorus_lib/examples/bookseller2.rs
@@ -8,6 +8,7 @@ use chorus_lib::{
     core::{ChoreoOp, Choreography, ChoreographyLocation, Located, Projector},
     transport::local::LocalTransport,
 };
+use chorus_lib::transport_config;
 use chrono::NaiveDate;
 
 #[derive(ChoreographyLocation)]
@@ -142,7 +143,8 @@ fn main() {
         i
     };
 
-    let transport = LocalTransport::<LocationSet!(Seller, Buyer1, Buyer2)>::new();
+    let config = transport_config!(Seller: (), Buyer1: (), Buyer2: ());
+    let transport = LocalTransport::new(&config);
     let seller_projector = Arc::new(Projector::new(Seller, transport.clone()));
     let buyer1_projector = Arc::new(Projector::new(Buyer1, transport.clone()));
     let buyer2_projector = Arc::new(Projector::new(Buyer2, transport.clone()));

--- a/chorus_lib/examples/bookseller2.rs
+++ b/chorus_lib/examples/bookseller2.rs
@@ -1,13 +1,13 @@
 extern crate chorus_lib;
 
 use std::collections::HashMap;
+use std::sync::Arc;
 use std::thread;
 
-use chorus_lib::transport_config;
 use chorus_lib::LocationSet;
 use chorus_lib::{
     core::{ChoreoOp, Choreography, ChoreographyLocation, Located, Projector},
-    transport::local::LocalTransport,
+    transport::local::{LocalTransport, LocalTransportChannel},
 };
 use chrono::NaiveDate;
 
@@ -144,22 +144,13 @@ fn main() {
     };
 
     let transport_channel =
-        LocalTransport::<LocationSet!(Seller, Buyer1, Buyer2)>::transport_channel();
+        Arc::new(LocalTransportChannel::<LocationSet!(Seller, Buyer1, Buyer2)>::new());
 
     println!("Tries to buy HoTT with one buyer");
     type OneBuyerBooksellerChoreography = BooksellerChoreography<OneBuyerDecider>;
     let mut handles = Vec::new();
     {
-        let config = transport_config!(
-            Seller,
-            Seller: (),
-            Buyer1: (),
-            Buyer2: (),
-        );
-
-        let transport_channel = transport_channel.clone();
-        let transport = LocalTransport::new(&config, transport_channel);
-
+        let transport = LocalTransport::new(Seller, Arc::clone(&transport_channel));
         let seller_projector = Projector::new(Seller, transport);
 
         let inventory = inventory.clone();
@@ -172,16 +163,7 @@ fn main() {
         }));
     }
     {
-        let config = transport_config!(
-            Buyer1,
-            Seller: (),
-            Buyer1: (),
-            Buyer2: (),
-        );
-
-        let transport_channel = transport_channel.clone();
-        let transport = LocalTransport::new(&config, transport_channel);
-
+        let transport = LocalTransport::new(Buyer1, Arc::clone(&transport_channel));
         let buyer1_projector = Projector::new(Buyer1, transport);
 
         handles.push(thread::spawn(move || {
@@ -197,16 +179,7 @@ fn main() {
         }));
     }
     {
-        let config = transport_config!(
-            Buyer2,
-            Seller: (),
-            Buyer1: (),
-            Buyer2: (),
-        );
-
-        let transport_channel = transport_channel.clone();
-        let transport = LocalTransport::new(&config, transport_channel);
-
+        let transport = LocalTransport::new(Buyer2, Arc::clone(&transport_channel));
         let buyer2_projector = Projector::new(Buyer2, transport);
 
         handles.push(thread::spawn(move || {
@@ -225,16 +198,7 @@ fn main() {
     type TwoBuyerBooksellerChoreography = BooksellerChoreography<TwoBuyerDecider>;
     let mut handles = Vec::new();
     {
-        let config = transport_config!(
-            Seller,
-            Seller: (),
-            Buyer1: (),
-            Buyer2: (),
-        );
-
-        let transport_channel = transport_channel.clone();
-        let transport = LocalTransport::new(&config, transport_channel);
-
+        let transport = LocalTransport::new(Seller, Arc::clone(&transport_channel));
         let seller_projector = Projector::new(Seller, transport);
 
         let inventory = inventory.clone();
@@ -247,16 +211,7 @@ fn main() {
         }));
     }
     {
-        let config = transport_config!(
-            Buyer1,
-            Seller: (),
-            Buyer1: (),
-            Buyer2: (),
-        );
-
-        let transport_channel = transport_channel.clone();
-        let transport = LocalTransport::new(&config, transport_channel);
-
+        let transport = LocalTransport::new(Buyer1, Arc::clone(&transport_channel));
         let buyer1_projector = Projector::new(Buyer1, transport);
 
         handles.push(thread::spawn(move || {
@@ -272,15 +227,7 @@ fn main() {
         }));
     }
     {
-        let config = transport_config!(
-            Buyer2,
-            Seller: (),
-            Buyer1: (),
-            Buyer2: (),
-        );
-
-        let transport_channel = transport_channel.clone();
-        let transport = LocalTransport::new(&config, transport_channel);
+        let transport = LocalTransport::new(Buyer2, Arc::clone(&transport_channel));
 
         let buyer2_projector = Projector::new(Buyer2, transport);
 

--- a/chorus_lib/examples/hello.rs
+++ b/chorus_lib/examples/hello.rs
@@ -40,21 +40,34 @@ impl Choreography for HelloWorldChoreography {
 
 fn main() {
     let mut handles: Vec<thread::JoinHandle<()>> = Vec::new();
-    // Create a local transport
-    let config = transport_config!(Alice: (), Bob: ());
-
-    let transport = LocalTransport::new(&config);
+    // Create a transport channel
+    let transport_channel = LocalTransport::<LocationSet!(Alice, Bob)>::transport_channel();
 
     // Run the choreography in two threads
     {
-        let transport = transport.clone();
+        let config = transport_config!(
+            Alice,
+            Alice: (),
+            Bob: ()
+        );
+
+        let transport_channel = transport_channel.clone();
+        let transport = LocalTransport::new(&config, transport_channel);
         handles.push(thread::spawn(move || {
             let p = Projector::new(Alice, transport);
             p.epp_and_run(HelloWorldChoreography);
         }));
     }
     {
-        let transport = transport.clone();
+        let config = transport_config!(
+            Alice,
+            Alice: (),
+            Bob: ()
+        );
+
+        let transport_channel = transport_channel.clone();
+        let transport = LocalTransport::new(&config, transport_channel);
+
         handles.push(thread::spawn(move || {
             let p = Projector::new(Bob, transport);
             p.epp_and_run(HelloWorldChoreography);

--- a/chorus_lib/examples/hello.rs
+++ b/chorus_lib/examples/hello.rs
@@ -4,6 +4,7 @@ use std::thread;
 
 use chorus_lib::core::{ChoreoOp, Choreography, ChoreographyLocation, Projector};
 use chorus_lib::transport::local::LocalTransport;
+use chorus_lib::transport_config;
 use chorus_lib::LocationSet;
 
 // --- Define two locations (Alice and Bob) ---
@@ -40,7 +41,9 @@ impl Choreography for HelloWorldChoreography {
 fn main() {
     let mut handles: Vec<thread::JoinHandle<()>> = Vec::new();
     // Create a local transport
-    let transport = LocalTransport::<LocationSet!(Alice, Bob)>::new();
+    let config = transport_config!(Alice: (), Bob: ());
+
+    let transport = LocalTransport::new(&config);
 
     // Run the choreography in two threads
     {

--- a/chorus_lib/examples/loc-poly.rs
+++ b/chorus_lib/examples/loc-poly.rs
@@ -6,6 +6,7 @@ use chorus_lib::core::{
     ChoreoOp, Choreography, ChoreographyLocation, Located, Portable, Projector,
 };
 use chorus_lib::transport::local::LocalTransport;
+use chorus_lib::transport_config;
 use chorus_lib::LocationSet;
 
 #[derive(ChoreographyLocation)]
@@ -57,7 +58,8 @@ impl Choreography<Located<i32, Alice>> for MainChoreography {
 }
 
 fn main() {
-    let transport = LocalTransport::<LocationSet!(Alice, Bob, Carol)>::new();
+    let config = transport_config!(Alice: (), Bob: (), Carol: ());
+    let transport = LocalTransport::new(&config);
     let mut handles = vec![];
     {
         let transport = transport.clone();

--- a/chorus_lib/examples/loc-poly.rs
+++ b/chorus_lib/examples/loc-poly.rs
@@ -58,11 +58,18 @@ impl Choreography<Located<i32, Alice>> for MainChoreography {
 }
 
 fn main() {
-    let config = transport_config!(Alice: (), Bob: (), Carol: ());
-    let transport = LocalTransport::new(&config);
+    let transport_channel = LocalTransport::<LocationSet!(Alice, Bob, Carol)>::transport_channel();
     let mut handles = vec![];
     {
-        let transport = transport.clone();
+        let config = transport_config!(
+            Alice,
+            Alice: (),
+            Bob: (),
+            Carol: (),
+        );
+
+        let transport_channel = transport_channel.clone();
+        let transport = LocalTransport::new(&config, transport_channel);
         handles.push(thread::spawn(|| {
             let p = Projector::new(Alice, transport);
             let v = p.epp_and_run(MainChoreography);
@@ -70,7 +77,15 @@ fn main() {
         }));
     }
     {
-        let transport = transport.clone();
+        let config = transport_config!(
+            Bob,
+            Alice: (),
+            Bob: (),
+            Carol: (),
+        );
+
+        let transport_channel = transport_channel.clone();
+        let transport = LocalTransport::new(&config, transport_channel);
         handles.push(thread::spawn(|| {
             let p = Projector::new(Bob, transport);
             p.epp_and_run(MainChoreography);

--- a/chorus_lib/examples/tic-tac-toe.rs
+++ b/chorus_lib/examples/tic-tac-toe.rs
@@ -294,9 +294,6 @@ fn main() {
         Box::new(UserBrain::new(args.player))
     };
 
-    // Create a transport channel
-    let transport_channel = HttpTransport::<LocationSet!(PlayerX, PlayerO)>::transport_channel();
-
     match args.player {
         'X' => {
             let config = transport_config!(
@@ -305,8 +302,7 @@ fn main() {
                 PlayerO: (args.opponent_hostname.as_str().to_string(), args.opponent_port)
             );
 
-            let transport_channel = transport_channel.clone();
-            let transport = HttpTransport::new(&config, transport_channel);
+            let transport = HttpTransport::new(&config);
 
             let projector = Projector::new(PlayerX, transport);
             projector.epp_and_run(TicTacToeChoreography {
@@ -321,8 +317,7 @@ fn main() {
             PlayerX: (args.opponent_hostname.as_str().to_string(), args.opponent_port)
             );
 
-            let transport_channel = transport_channel.clone();
-            let transport = HttpTransport::new(&config, transport_channel);
+            let transport = HttpTransport::new(&config);
             let projector = Projector::new(PlayerO, transport);
             projector.epp_and_run(TicTacToeChoreography {
                 brain_for_x: projector.remote(PlayerX),

--- a/chorus_lib/examples/tic-tac-toe.rs
+++ b/chorus_lib/examples/tic-tac-toe.rs
@@ -1,14 +1,16 @@
 /// Choreographic tik-tak-toe game
 extern crate chorus_lib;
 
+use chorus_lib::transport_config;
 use chorus_lib::{
     core::{
         ChoreoOp, Choreography, ChoreographyLocation, Deserialize, Located, Projector, Serialize,
     },
-    http_config,
+    // http_config,
     transport::http::HttpTransport,
     LocationSet,
 };
+
 use clap::Parser;
 use std::io::Write;
 use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
@@ -294,14 +296,8 @@ fn main() {
 
     match args.player {
         'X' => {
-            // let mut config = HttpConfig::<LocationSet!(PlayerX, PlayerO)>::new();
-            // config.insert(PlayerX, (args.hostname.as_str(), args.port));
-            // config.insert(
-            //     PlayerO,
-            //     (args.opponent_hostname.as_str(), args.opponent_port),
-            // );
-            let config = http_config!(PlayerX: (args.hostname.as_str(), args.port), 
-                                      PlayerO: (args.opponent_hostname.as_str(), args.opponent_port));
+            let config = transport_config!(PlayerX: (args.hostname.as_str().to_string(), args.port), 
+                                      PlayerO: (args.opponent_hostname.as_str().to_string(), args.opponent_port));
             let transport = HttpTransport::new(PlayerX, &config);
             let projector = Projector::new(PlayerX, transport);
             projector.epp_and_run(TicTacToeChoreography {
@@ -310,14 +306,8 @@ fn main() {
             });
         }
         'O' => {
-            // let mut config = HttpConfig::<LocationSet!(PlayerX, PlayerO)>::new();
-            // config.insert(PlayerO, (args.hostname.as_str(), args.port));
-            // config.insert(
-            //     PlayerX,
-            //     (args.opponent_hostname.as_str(), args.opponent_port),
-            // );
-            let config = http_config!(PlayerO: (args.hostname.as_str(), args.port), 
-                                      PlayerX: (args.opponent_hostname.as_str(), args.opponent_port));
+            let config = transport_config!(PlayerO: (args.hostname.as_str().to_string(), args.port), 
+                                      PlayerX: (args.opponent_hostname.as_str().to_string(), args.opponent_port));
             let transport = HttpTransport::new(PlayerO, &config);
             let projector = Projector::new(PlayerO, transport);
             projector.epp_and_run(TicTacToeChoreography {

--- a/chorus_lib/examples/tic-tac-toe.rs
+++ b/chorus_lib/examples/tic-tac-toe.rs
@@ -294,11 +294,20 @@ fn main() {
         Box::new(UserBrain::new(args.player))
     };
 
+    // Create a transport channel
+    let transport_channel = HttpTransport::<LocationSet!(PlayerX, PlayerO)>::transport_channel();
+
     match args.player {
         'X' => {
-            let config = transport_config!(PlayerX: (args.hostname.as_str().to_string(), args.port), 
-                                      PlayerO: (args.opponent_hostname.as_str().to_string(), args.opponent_port));
-            let transport = HttpTransport::new(PlayerX, &config);
+            let config = transport_config!(
+                PlayerX,
+                PlayerX: (args.hostname.as_str().to_string(), args.port),
+                PlayerO: (args.opponent_hostname.as_str().to_string(), args.opponent_port)
+            );
+
+            let transport_channel = transport_channel.clone();
+            let transport = HttpTransport::new(&config, transport_channel);
+
             let projector = Projector::new(PlayerX, transport);
             projector.epp_and_run(TicTacToeChoreography {
                 brain_for_x: projector.local(brain),
@@ -306,9 +315,14 @@ fn main() {
             });
         }
         'O' => {
-            let config = transport_config!(PlayerO: (args.hostname.as_str().to_string(), args.port), 
-                                      PlayerX: (args.opponent_hostname.as_str().to_string(), args.opponent_port));
-            let transport = HttpTransport::new(PlayerO, &config);
+            let config = transport_config!(
+            PlayerO,
+            PlayerO: (args.hostname.as_str().to_string(), args.port),
+            PlayerX: (args.opponent_hostname.as_str().to_string(), args.opponent_port)
+            );
+
+            let transport_channel = transport_channel.clone();
+            let transport = HttpTransport::new(&config, transport_channel);
             let projector = Projector::new(PlayerO, transport);
             projector.epp_and_run(TicTacToeChoreography {
                 brain_for_x: projector.remote(PlayerX),

--- a/chorus_lib/examples/tic-tac-toe.rs
+++ b/chorus_lib/examples/tic-tac-toe.rs
@@ -297,8 +297,7 @@ fn main() {
     match args.player {
         'X' => {
             let config = transport_config!(
-                PlayerX,
-                PlayerX: (args.hostname.as_str().to_string(), args.port),
+                PlayerX => (args.hostname.as_str().to_string(), args.port),
                 PlayerO: (args.opponent_hostname.as_str().to_string(), args.opponent_port)
             );
 
@@ -312,8 +311,7 @@ fn main() {
         }
         'O' => {
             let config = transport_config!(
-            PlayerO,
-            PlayerO: (args.hostname.as_str().to_string(), args.port),
+            PlayerO => (args.hostname.as_str().to_string(), args.port),
             PlayerX: (args.opponent_hostname.as_str().to_string(), args.opponent_port)
             );
 

--- a/chorus_lib/src/core.rs
+++ b/chorus_lib/src/core.rs
@@ -280,7 +280,7 @@ pub trait Choreography<R = ()> {
 /// Provides methods to send and receive messages.
 ///
 /// The trait provides methods to send and receive messages between locations. Implement this trait to define a custom transport.
-pub trait Transport<L> {
+pub trait Transport<L, TargetLocation> {
     /// Returns a list of locations.
     fn locations(&self) -> Vec<String>;
     /// Sends a message from `from` to `to`.
@@ -290,7 +290,7 @@ pub trait Transport<L> {
 }
 
 /// Provides a method to perform end-point projection.
-pub struct Projector<LS: HList, L1: ChoreographyLocation, T: Transport<LS>, Index>
+pub struct Projector<LS: HList, L1: ChoreographyLocation, T: Transport<LS, L1>, Index>
 where
     L1: Member<LS, Index>,
 {
@@ -300,7 +300,7 @@ where
     index: PhantomData<Index>,
 }
 
-impl<LS: HList, L1: ChoreographyLocation, B: Transport<LS>, Index> Projector<LS, L1, B, Index>
+impl<LS: HList, L1: ChoreographyLocation, B: Transport<LS, L1>, Index> Projector<LS, L1, B, Index>
 where
     L1: Member<LS, Index>,
 {
@@ -349,14 +349,14 @@ where
     where
         L: Subset<LS, IndexSet>,
     {
-        struct EppOp<'a, L: HList, L1: ChoreographyLocation, LS: HList, B: Transport<LS>> {
+        struct EppOp<'a, L: HList, L1: ChoreographyLocation, LS: HList, B: Transport<LS, L1>> {
             target: PhantomData<L1>,
             transport: &'a B,
             locations: Vec<String>,
             marker: PhantomData<L>,
-            location_set: PhantomData<LS>,
+            projector_location_set: PhantomData<LS>,
         }
-        impl<'a, L: HList, T: ChoreographyLocation, LS: HList, B: Transport<LS>> ChoreoOp<L>
+        impl<'a, L: HList, T: ChoreographyLocation, LS: HList, B: Transport<LS, T>> ChoreoOp<L>
             for EppOp<'a, L, T, LS, B>
         {
             fn locally<V, L1: ChoreographyLocation, Index>(
@@ -425,7 +425,7 @@ where
                     transport: &self.transport,
                     locations: self.transport.locations(),
                     marker: PhantomData::<M>,
-                    location_set: PhantomData::<LS>,
+                    projector_location_set: PhantomData::<LS>,
                 };
                 choreo.run(&op)
             }
@@ -444,7 +444,7 @@ where
                             transport: self.transport,
                             locations: locs_vec.clone(),
                             marker: PhantomData::<S>,
-                            location_set: PhantomData::<LS>,
+                            projector_location_set: PhantomData::<LS>,
                         };
                         return choreo.run(&op);
                     }
@@ -457,7 +457,7 @@ where
             transport: &self.transport,
             locations: self.transport.locations(),
             marker: PhantomData::<L>,
-            location_set: PhantomData::<LS>,
+            projector_location_set: PhantomData::<LS>,
         };
         choreo.run(&op)
     }

--- a/chorus_lib/src/core.rs
+++ b/chorus_lib/src/core.rs
@@ -171,6 +171,22 @@ where
 {
 }
 
+/// Equal trait
+pub trait Equal<L: HList, Index> {}
+
+// Base case: HNil is equal to HNil
+impl Equal<HNil, Here> for HNil {}
+
+// Recursive case: Head::Tail is equal to L if
+// 1. Head is a member of L
+// 2. Tail is equal to the remainder of L
+impl<L: HList, Head, Tail, Index1, Index2> Equal<L, HCons<Index1, Index2>> for HCons<Head, Tail>
+where
+    Head: Member<L, Index1>,
+    Tail: Equal<Head::Remainder, Index2>,
+{
+}
+
 /// Provides a method to work with located values at the current location
 pub struct Unwrapper<L1: ChoreographyLocation> {
     phantom: PhantomData<L1>,

--- a/chorus_lib/src/transport.rs
+++ b/chorus_lib/src/transport.rs
@@ -3,7 +3,7 @@
 pub mod http;
 pub mod local;
 
-use std::{collections::HashMap, sync::Arc};
+use std::sync::Arc;
 
 /// A generic struct for configuration of `Transport`.
 #[derive(Clone)]
@@ -16,6 +16,26 @@ pub struct TransportConfig<L: crate::core::HList, InfoType, TargetInfoType> {
     pub location_set: std::marker::PhantomData<L>,
     // pub transport_channel: TransportChannel<L>,
 
+}
+
+/// A Transport channel used between multiple `Transport`s.
+pub struct TransportChannel<L: crate::core::HList, T: Send + Sync>{
+    /// The location set where the channel is defined on.
+    pub location_set: std::marker::PhantomData<L>,
+    queue_map: Arc<T>,
+}
+
+impl<L, T> Clone for TransportChannel<L, T>
+where
+    L: crate::core::HList,
+    T: Send + Sync,
+{
+    fn clone(&self) -> Self {
+        Self {
+            location_set: self.location_set.clone(),
+            queue_map: self.queue_map.clone(),  // This clones the Arc, not the underlying data
+        }
+    }
 }
 
 /// This macro makes a `TransportConfig`.
@@ -49,7 +69,6 @@ macro_rules! transport_config {
                 if $loc::name().to_string() != choreography_name{
                     config.insert($loc::name().to_string(), $val);
                 } else {
-                    println!("heyyyy");
                     target_info = Some($val);
                 }
             )*

--- a/chorus_lib/src/transport.rs
+++ b/chorus_lib/src/transport.rs
@@ -3,14 +3,18 @@
 pub mod http;
 pub mod local;
 
+use std::{collections::HashMap, sync::Arc};
+
 /// A generic struct for configuration of `Transport`.
 #[derive(Clone)]
 pub struct TransportConfig<L: crate::core::HList, InfoType, TargetInfoType> {
     /// The information about locations
     pub info: std::collections::HashMap<String, InfoType>,
+    /// The information about the target choreography
     pub target_info: (String, TargetInfoType),
     /// The struct is parametrized by the location set (`L`).
     pub location_set: std::marker::PhantomData<L>,
+    // pub transport_channel: TransportChannel<L>,
 
 }
 

--- a/chorus_lib/src/transport.rs
+++ b/chorus_lib/src/transport.rs
@@ -24,23 +24,17 @@ pub struct TransportConfig<
 /// This macro makes a `TransportConfig`.
 #[macro_export]
 macro_rules! transport_config {
-    ( $choreography_loc:ident, $( $loc:ident : $val:expr ),* $(,)? ) => {
+    ( $choreography_loc:ident => $choreography_val:expr, $( $loc:ident : $val:expr ),* $(,)? ) => {
         {
-            let choreography_name = $choreography_loc::name().to_string();
             let mut config = std::collections::HashMap::new();
-            let mut target_info = None;
             $(
-                if $loc::name().to_string() != choreography_name{
-                    config.insert($loc::name().to_string(), $val);
-                } else {
-                    target_info = Some($val);
-                }
+                config.insert($loc::name().to_string(), $val);
             )*
 
-            $crate::transport::TransportConfig::<$crate::LocationSet!($( $loc ),*), _, _, _> {
+            $crate::transport::TransportConfig::<$crate::LocationSet!($choreography_loc, $( $loc ),*), _, _, _> {
                 info: config,
                 location_set: core::marker::PhantomData,
-                target_info: ($choreography_loc, target_info.unwrap()),
+                target_info: ($choreography_loc, $choreography_val),
             }
         }
     };

--- a/chorus_lib/src/transport.rs
+++ b/chorus_lib/src/transport.rs
@@ -2,3 +2,30 @@
 
 pub mod http;
 pub mod local;
+
+/// A generic struct for configuration of `Transport`.
+#[derive(Clone)]
+pub struct TransportConfig<L: crate::core::HList, InfoType> {
+    /// The information about locations
+    pub info: std::collections::HashMap<String, InfoType>,
+    /// The struct is parametrized by the location set (`L`).
+    pub location_set: std::marker::PhantomData<L>,
+}
+
+/// This macro makes a `TransportConfig`.
+#[macro_export]
+macro_rules! transport_config {
+    ( $( $loc:ident : $val:expr ),* $(,)? ) => {
+        {
+            let mut config = std::collections::HashMap::new();
+            $(
+                config.insert($loc::name().to_string(), $val);
+            )*
+
+            $crate::transport::TransportConfig::<$crate::LocationSet!($( $loc ),*), _> {
+                info: config,
+                location_set: core::marker::PhantomData
+            }
+        }
+    };
+}

--- a/chorus_lib/src/transport.rs
+++ b/chorus_lib/src/transport.rs
@@ -4,14 +4,15 @@ pub mod http;
 pub mod local;
 
 use std::sync::Arc;
+use crate::core::ChoreographyLocation;
 
 /// A generic struct for configuration of `Transport`.
 #[derive(Clone)]
-pub struct TransportConfig<L: crate::core::HList, InfoType, TargetInfoType> {
+pub struct TransportConfig<L: crate::core::HList, InfoType, TargetLocation: ChoreographyLocation, TargetInfoType> {
     /// The information about locations
     pub info: std::collections::HashMap<String, InfoType>,
     /// The information about the target choreography
-    pub target_info: (String, TargetInfoType),
+    pub target_info: (TargetLocation, TargetInfoType),
     /// The struct is parametrized by the location set (`L`).
     pub location_set: std::marker::PhantomData<L>,
     // pub transport_channel: TransportChannel<L>,
@@ -75,10 +76,10 @@ macro_rules! transport_config {
 
             // println!("{}, {}", target_info.unwrap().0, target.info.unwrap().1);
 
-            $crate::transport::TransportConfig::<$crate::LocationSet!($( $loc ),*), _, _> {
+            $crate::transport::TransportConfig::<$crate::LocationSet!($( $loc ),*), _, _, _> {
                 info: config,
                 location_set: core::marker::PhantomData,
-                target_info: (choreography_name, target_info.unwrap()),
+                target_info: ($choreography_loc, target_info.unwrap()),
             }
         }
     };

--- a/chorus_lib/src/transport.rs
+++ b/chorus_lib/src/transport.rs
@@ -5,26 +5,57 @@ pub mod local;
 
 /// A generic struct for configuration of `Transport`.
 #[derive(Clone)]
-pub struct TransportConfig<L: crate::core::HList, InfoType> {
+pub struct TransportConfig<L: crate::core::HList, InfoType, TargetInfoType> {
     /// The information about locations
     pub info: std::collections::HashMap<String, InfoType>,
+    pub target_info: (String, TargetInfoType),
     /// The struct is parametrized by the location set (`L`).
     pub location_set: std::marker::PhantomData<L>,
+
 }
 
 /// This macro makes a `TransportConfig`.
+// #[macro_export]
+// macro_rules! transport_config {
+//     ( $( $loc:ident : $val:expr ),* $(,)? ) => {
+//         {
+//             let mut config = std::collections::HashMap::new();
+//             $(
+//                 config.insert($loc::name().to_string(), $val);
+//             )*
+
+//             $crate::transport::TransportConfig::<$crate::LocationSet!($( $loc ),*), _> {
+//                 info: config,
+//                 location_set: core::marker::PhantomData
+//             }
+//         }
+//     };
+// }
+
+
+/// This macro makes a `TransportConfig`; V2.
 #[macro_export]
 macro_rules! transport_config {
-    ( $( $loc:ident : $val:expr ),* $(,)? ) => {
+    ( $choreography_loc:ident, $( $loc:ident : $val:expr ),* $(,)? ) => {
         {
+            let choreography_name = $choreography_loc::name().to_string();
             let mut config = std::collections::HashMap::new();
+            let mut target_info = None;
             $(
-                config.insert($loc::name().to_string(), $val);
+                if $loc::name().to_string() != choreography_name{
+                    config.insert($loc::name().to_string(), $val);
+                } else {
+                    println!("heyyyy");
+                    target_info = Some($val);
+                }
             )*
 
-            $crate::transport::TransportConfig::<$crate::LocationSet!($( $loc ),*), _> {
+            // println!("{}, {}", target_info.unwrap().0, target.info.unwrap().1);
+
+            $crate::transport::TransportConfig::<$crate::LocationSet!($( $loc ),*), _, _> {
                 info: config,
-                location_set: core::marker::PhantomData
+                location_set: core::marker::PhantomData,
+                target_info: (choreography_name, target_info.unwrap()),
             }
         }
     };

--- a/chorus_lib/src/transport.rs
+++ b/chorus_lib/src/transport.rs
@@ -4,7 +4,6 @@ pub mod http;
 pub mod local;
 
 use crate::core::ChoreographyLocation;
-use std::sync::Arc;
 
 /// A generic struct for configuration of `Transport`.
 #[derive(Clone)]
@@ -22,26 +21,6 @@ pub struct TransportConfig<
     pub location_set: std::marker::PhantomData<L>,
 }
 
-/// A Transport channel used between multiple `Transport`s.
-pub struct TransportChannel<L: crate::core::HList, T: Send + Sync> {
-    /// The location set where the channel is defined on.
-    pub location_set: std::marker::PhantomData<L>,
-    queue_map: Arc<T>,
-}
-
-impl<L, T> Clone for TransportChannel<L, T>
-where
-    L: crate::core::HList,
-    T: Send + Sync,
-{
-    fn clone(&self) -> Self {
-        Self {
-            location_set: self.location_set.clone(),
-            queue_map: self.queue_map.clone(), // This clones the Arc, not the underlying data
-        }
-    }
-}
-
 /// This macro makes a `TransportConfig`.
 #[macro_export]
 macro_rules! transport_config {
@@ -57,8 +36,6 @@ macro_rules! transport_config {
                     target_info = Some($val);
                 }
             )*
-
-            // println!("{}, {}", target_info.unwrap().0, target.info.unwrap().1);
 
             $crate::transport::TransportConfig::<$crate::LocationSet!($( $loc ),*), _, _, _> {
                 info: config,

--- a/chorus_lib/src/transport.rs
+++ b/chorus_lib/src/transport.rs
@@ -3,24 +3,27 @@
 pub mod http;
 pub mod local;
 
-use std::sync::Arc;
 use crate::core::ChoreographyLocation;
+use std::sync::Arc;
 
 /// A generic struct for configuration of `Transport`.
 #[derive(Clone)]
-pub struct TransportConfig<L: crate::core::HList, InfoType, TargetLocation: ChoreographyLocation, TargetInfoType> {
+pub struct TransportConfig<
+    L: crate::core::HList,
+    InfoType,
+    TargetLocation: ChoreographyLocation,
+    TargetInfoType,
+> {
     /// The information about locations
     pub info: std::collections::HashMap<String, InfoType>,
     /// The information about the target choreography
     pub target_info: (TargetLocation, TargetInfoType),
     /// The struct is parametrized by the location set (`L`).
     pub location_set: std::marker::PhantomData<L>,
-    // pub transport_channel: TransportChannel<L>,
-
 }
 
 /// A Transport channel used between multiple `Transport`s.
-pub struct TransportChannel<L: crate::core::HList, T: Send + Sync>{
+pub struct TransportChannel<L: crate::core::HList, T: Send + Sync> {
     /// The location set where the channel is defined on.
     pub location_set: std::marker::PhantomData<L>,
     queue_map: Arc<T>,
@@ -34,31 +37,12 @@ where
     fn clone(&self) -> Self {
         Self {
             location_set: self.location_set.clone(),
-            queue_map: self.queue_map.clone(),  // This clones the Arc, not the underlying data
+            queue_map: self.queue_map.clone(), // This clones the Arc, not the underlying data
         }
     }
 }
 
 /// This macro makes a `TransportConfig`.
-// #[macro_export]
-// macro_rules! transport_config {
-//     ( $( $loc:ident : $val:expr ),* $(,)? ) => {
-//         {
-//             let mut config = std::collections::HashMap::new();
-//             $(
-//                 config.insert($loc::name().to_string(), $val);
-//             )*
-
-//             $crate::transport::TransportConfig::<$crate::LocationSet!($( $loc ),*), _> {
-//                 info: config,
-//                 location_set: core::marker::PhantomData
-//             }
-//         }
-//     };
-// }
-
-
-/// This macro makes a `TransportConfig`; V2.
 #[macro_export]
 macro_rules! transport_config {
     ( $choreography_loc:ident, $( $loc:ident : $val:expr ),* $(,)? ) => {

--- a/chorus_lib/src/transport/http.rs
+++ b/chorus_lib/src/transport/http.rs
@@ -63,8 +63,7 @@ impl<L: HList> HttpTransport<L> {
 
     /// Creates a new `HttpTransport` instance from the projection target and a configuration.
     pub fn new<C: ChoreographyLocation, Index>(
-        _loc: C,
-        http_config: &TransportConfig<L, (String, u16), (String, u16)>,
+        http_config: &TransportConfig<L, (String, u16), C, (String, u16)>,
         transport_channel: TransportChannel<L, Arc<QueueMap>>
     ) -> Self
     where
@@ -182,7 +181,7 @@ mod tests {
             
             handles.push(thread::spawn(move || {
                 wait.recv().unwrap(); // wait for Bob to start
-                let transport = HttpTransport::new(Alice, &config, transport_channel);
+                let transport = HttpTransport::new(&config, transport_channel);
                 transport.send::<i32>(Alice::name(), Bob::name(), &v);
             }));
         }
@@ -197,7 +196,7 @@ mod tests {
             
             let transport_channel = transport_channel.clone();
             handles.push(thread::spawn(move || {
-                let transport = HttpTransport::new(Bob, &config, transport_channel);
+                let transport = HttpTransport::new(&config, transport_channel);
                 signal.send(()).unwrap();
                 let v2 = transport.receive::<i32>(Alice::name(), Bob::name());
                 assert_eq!(v, v2);
@@ -227,7 +226,7 @@ mod tests {
 
             handles.push(thread::spawn(move || {
                 signal.send(()).unwrap();
-                let transport = HttpTransport::new(Alice, &config, transport_channel);
+                let transport = HttpTransport::new(&config, transport_channel);
                 transport.send::<i32>(Alice::name(), Bob::name(), &v);
             }));
         }
@@ -244,7 +243,7 @@ mod tests {
                 // wait for Alice to start, which forces Alice to retry
                 wait.recv().unwrap();
                 sleep(Duration::from_millis(100));
-                let transport = HttpTransport::new(Bob, &config, transport_channel);
+                let transport = HttpTransport::new(&config, transport_channel);
                 let v2 = transport.receive::<i32>(Alice::name(), Bob::name());
                 assert_eq!(v, v2);
             }));

--- a/chorus_lib/src/transport/http.rs
+++ b/chorus_lib/src/transport/http.rs
@@ -17,7 +17,7 @@ use crate::transport::{TransportChannel, TransportConfig};
 use crate::{transport_config, LocationSet};
 
 use crate::{
-    core::{ChoreographyLocation, HList, Member, Portable, Transport},
+    core::{ChoreographyLocation, Equal, HList, Member, Portable, Transport},
     utils::queue::BlockingQueue,
 };
 
@@ -54,12 +54,13 @@ impl<L: HList> HttpTransport<L> {
     }
 
     /// Creates a new `HttpTransport` instance from the projection target and a configuration.
-    pub fn new<C: ChoreographyLocation, Index>(
-        http_config: &TransportConfig<L, (String, u16), C, (String, u16)>,
+    pub fn new<C: ChoreographyLocation, L2: HList, Index, IndexList>(
+        http_config: &TransportConfig<L2, (String, u16), C, (String, u16)>,
         transport_channel: TransportChannel<L, QueueMap>,
     ) -> Self
     where
         C: Member<L, Index>,
+        L2: Equal<L, IndexList>,
     {
         let info = &http_config.info;
 

--- a/chorus_lib/src/transport/local.rs
+++ b/chorus_lib/src/transport/local.rs
@@ -11,7 +11,7 @@ use crate::transport::{TransportChannel, TransportConfig};
 #[cfg(test)]
 use crate::{transport_config, LocationSet};
 
-use crate::core::{ChoreographyLocation, HList, Portable, Transport};
+use crate::core::{ChoreographyLocation, HList, Portable, Transport, Equal};
 use crate::utils::queue::BlockingQueue;
 
 type QueueMap = HashMap<String, HashMap<String, BlockingQueue<String>>>;
@@ -48,10 +48,10 @@ impl<L: HList> LocalTransport<L> {
     }
 
     /// Creates a new `LocalTransport` instance from a `TransportConfig` and a `TransportChannel`.
-    pub fn new<C: ChoreographyLocation>(
-        _local_config: &TransportConfig<L, (), C, ()>,
+    pub fn new<C: ChoreographyLocation, L2: HList, IndexList>(
+        _local_config: &TransportConfig<L2, (), C, ()>,
         transport_channel: TransportChannel<L, QueueMap>,
-    ) -> Self {
+    ) -> Self where L2: Equal<L, IndexList>{
         let locations_list = L::to_string_list();
 
         let mut locations_vec = Vec::new();
@@ -121,6 +121,7 @@ mod tests {
                 Alice: (),
                 Bob: ()
             );
+
             let transport_channel = transport_channel.clone();
 
             let transport = LocalTransport::new(&config, transport_channel);

--- a/chorus_lib/src/transport/local.rs
+++ b/chorus_lib/src/transport/local.rs
@@ -29,7 +29,7 @@ pub struct LocalTransport<L: HList> {
 
 impl<L: HList> LocalTransport<L> {
     /// Creates a new `LocalTransport` instance from a list of locations.
-    pub fn new(local_config: &TransportConfig<L, ()>) -> Self {
+    pub fn new(local_config: &TransportConfig<L, (), ()>) -> Self {
         let mut queue_map: QueueMap = HashMap::new();
         let locations_list = L::to_string_list();
 
@@ -90,6 +90,7 @@ mod tests {
         let v = 42;
 
         let config = transport_config!(
+            Alice,
             Alice: (),
             Bob: ()
         );
@@ -98,13 +99,25 @@ mod tests {
 
         let mut handles = Vec::new();
         {
-            let transport = transport.clone();
+            let config = transport_config!(
+                Alice,
+                Alice: (),
+                Bob: ()
+            );
+            // let transport = transport.clone();
+            let transport = LocalTransport::new(&config);
             handles.push(thread::spawn(move || {
                 transport.send::<i32>(Alice::name(), Bob::name(), &v);
             }));
         }
         {
-            let transport = transport.clone();
+            let config = transport_config!(
+                Bob,
+                Alice: (),
+                Bob: ()
+            );
+            // let transport = transport.clone();
+            let transport = LocalTransport::new(&config);
             handles.push(thread::spawn(move || {
                 let v2 = transport.receive::<i32>(Alice::name(), Bob::name());
                 assert_eq!(v, v2);

--- a/chorus_lib/src/transport/local.rs
+++ b/chorus_lib/src/transport/local.rs
@@ -10,7 +10,7 @@ use std::marker::PhantomData;
 use crate::transport::{TransportConfig, TransportChannel};
 use crate::{transport_config, LocationSet};
 
-use crate::core::{HList, Portable, Transport};
+use crate::core::{HList, Portable, Transport, ChoreographyLocation};
 use crate::utils::queue::BlockingQueue;
 
 type QueueMap = HashMap<String, HashMap<String, BlockingQueue<String>>>;
@@ -47,7 +47,7 @@ impl<L: HList> LocalTransport<L> {
     }
 
     /// Creates a new `LocalTransport` instance from a list of locations.
-    pub fn new(_local_config: &TransportConfig<L, (), ()>, transport_channel: TransportChannel<L, Arc<QueueMap>>) -> Self {
+    pub fn new<C: ChoreographyLocation>(_local_config: &TransportConfig<L, (), C, ()>, transport_channel: TransportChannel<L, Arc<QueueMap>>) -> Self {
         let locations_list = L::to_string_list();
 
         let mut locations_vec = Vec::new();

--- a/chorus_lib/src/transport/local.rs
+++ b/chorus_lib/src/transport/local.rs
@@ -7,6 +7,9 @@ use serde_json;
 
 use std::marker::PhantomData;
 
+use crate::transport::TransportConfig;
+use crate::transport_config;
+
 use crate::core::{HList, Portable, Transport};
 use crate::utils::queue::BlockingQueue;
 
@@ -26,7 +29,7 @@ pub struct LocalTransport<L: HList> {
 
 impl<L: HList> LocalTransport<L> {
     /// Creates a new `LocalTransport` instance from a list of locations.
-    pub fn new() -> Self {
+    pub fn new(local_config: &TransportConfig<L, ()>) -> Self {
         let mut queue_map: QueueMap = HashMap::new();
         let locations_list = L::to_string_list();
 
@@ -85,7 +88,14 @@ mod tests {
     #[test]
     fn test_local_transport() {
         let v = 42;
-        let transport = LocalTransport::<crate::LocationSet!(Alice, Bob)>::new();
+
+        let config = transport_config!(
+            Alice: (),
+            Bob: ()
+        );
+
+        let transport = LocalTransport::new(&config);
+
         let mut handles = Vec::new();
         {
             let transport = transport.clone();

--- a/chorus_lib/src/transport/local.rs
+++ b/chorus_lib/src/transport/local.rs
@@ -11,7 +11,7 @@ use crate::transport::{TransportChannel, TransportConfig};
 #[cfg(test)]
 use crate::{transport_config, LocationSet};
 
-use crate::core::{ChoreographyLocation, HList, Portable, Transport, Equal};
+use crate::core::{ChoreographyLocation, Equal, HList, Portable, Transport};
 use crate::utils::queue::BlockingQueue;
 
 type QueueMap = HashMap<String, HashMap<String, BlockingQueue<String>>>;
@@ -51,7 +51,10 @@ impl<L: HList> LocalTransport<L> {
     pub fn new<C: ChoreographyLocation, L2: HList, IndexList>(
         _local_config: &TransportConfig<L2, (), C, ()>,
         transport_channel: TransportChannel<L, QueueMap>,
-    ) -> Self where L2: Equal<L, IndexList>{
+    ) -> Self
+    where
+        L2: Equal<L, IndexList>,
+    {
         let locations_list = L::to_string_list();
 
         let mut locations_vec = Vec::new();


### PR DESCRIPTION
This allows the user to specify different types of information for the target location when building the transport.

if users want to make a `HttpTransport`, they currently do this: 

```rust
use crate::transport::TransportConfig;
use crate::transport_config;

// for http transport:
let config = transport_config!(
                Alice => ("0.0.0.0".to_string(), 9021),
                Bob: ("localhost".to_string(), 9020)
                Carol: ("localhost".to_string(), 9022)
            );
let alice_transport = HttpTransport::new(&config);
```

But with this pull request, we support custom Transports where the information type for `Alice` is different then the one for `Bob` and `Carol`. Something like this:

```rust
// for a custom transport:
let config = transport_config!(
                Alice => value_of_type_a,
                Bob: value_of_type_b,
                Carol: another_value_of_type_b
            );

let alice_transport = CustomTransport::new(&config);
```